### PR TITLE
Fix for /region claim failing due to non-existent overlapping region

### DIFF
--- a/src/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
+++ b/src/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
@@ -148,7 +148,7 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
                             || (rMinPoint.getBlockY() > max.getBlockY() && rMaxPoint.getBlockY() > max.getBlockY()))
                     && ((rMinPoint.getBlockZ() < min.getBlockZ() && rMaxPoint.getBlockZ() < min.getBlockZ())
                             || (rMinPoint.getBlockZ() > max.getBlockZ() && rMaxPoint.getBlockZ() > max.getBlockZ())) ) {
-                intersectingRegions.add(regions.get(i));
+                //intersectingRegions.add(regions.get(i));
                 continue;
             }
 


### PR DESCRIPTION
First check is to discount regions that are entirely outside the region that is being claimed, therefore it shouldn't add them to the list of overlapping regions.
