### PR TITLE
Don't deny placing a blacklisted item if the block clicked is a chest.

### DIFF
--- a/src/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
+++ b/src/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
@@ -301,19 +301,26 @@ public class WorldGuardPlayerListener extends PlayerListener {
         }
 
         if (wcfg.getBlacklist() != null) {
-            if (!wcfg.getBlacklist().check(
-                    new ItemUseBlacklistEvent(plugin.wrapPlayer(player), toVector(block),
-                    item.getTypeId()), false, false)) {
-                event.setCancelled(true);
-                return;
+            if((block.getType() != Material.CHEST
+                && block.getType() != Material.DISPENSER
+                && block.getType() != Material.FURNACE
+                && block.getType() != Material.BURNING_FURNACE)) {
+                if (!wcfg.getBlacklist().check(
+                        new ItemUseBlacklistEvent(plugin.wrapPlayer(player), toVector(block),
+                        item.getTypeId()), false, false)) {
+                    event.setCancelled(true);
+                    return;
+                }
+
+                if (!wcfg.getBlacklist().check(
+                        new BlockInteractBlacklistEvent(plugin.wrapPlayer(player), toVector(block),
+                        block.getTypeId()), false, false)) {
+                    event.setCancelled(true);
+                    return;
+                }
+
             }
-            
-            if (!wcfg.getBlacklist().check(
-                    new BlockInteractBlacklistEvent(plugin.wrapPlayer(player), toVector(block),
-                    block.getTypeId()), false, false)) {
-                event.setCancelled(true);
-                return;
-            }
+
         }
 
         if ((block.getType() == Material.CHEST


### PR DESCRIPTION
On my server, people often trigger the WorldGuard blacklist if they're holding a blacklisted item while opening a chest. This pull request makes it so that the blacklist is activated only if the clicked block is not a chest, dispenser, or furnace.
