### PR TITLE
Filter "/region list" by user.

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
@@ -484,8 +484,11 @@ public class RegionCommands {
 
         String[] regionIDList = new String[size];
         int index = 0;
+        boolean show = false;
+        String prefix = "";
         for (String id : regions.keySet()) {
-            boolean show = false;
+            show = false;
+            prefix = "";
             if (name.isEmpty()) {
                 show = true;
             }
@@ -493,15 +496,26 @@ public class RegionCommands {
                 if (own) {
                     if (regions.get(id).isOwner(localPlayer)) {
                         show = true;
+                        prefix += "+";
+                    }
+                    else if (regions.get(id).isMember(localPlayer)) {
+                        show = true;
+                        prefix += "-";
                     }
                 }
                 else {
-                    if (regions.get(id).getOwners().getPlayers().contains(name))
+                    if (regions.get(id).getOwners().getPlayers().contains(name)) {
                         show = true;
+                        prefix += "+";
+                    }
+                    if (regions.get(id).getMembers().getPlayers().contains(name)) {
+                        show = true;
+                        prefix += "-";
+                    }
                 }
             }
             if (show) {
-                regionIDList[index] = id;
+                regionIDList[index] = prefix + " " + id;
                 index++;
             }
         }
@@ -521,7 +535,7 @@ public class RegionCommands {
                     break;
                 }
                 sender.sendMessage(ChatColor.YELLOW.toString() + (i + 1) +
-                        ". " + regionIDList[i]);
+                        "." + regionIDList[i]);
             }
         }
     }


### PR DESCRIPTION
The syntax may not be to everyone's taste, but it's the best I could come up with that would keep it compatible.
I've added a new argument to "/region list". Without it, it behaves as before, and with it, the existing arguments work as before.
Put a player name as the first argument, with a "." in front, and only the regions of that user will be listed.
Using ".me", just "." or a "." with your own username lists your regions, and there's a new permission "worldguard.region.list.own" for this, so people can be given permission to list only their own regions.
Sorry about the duplicate request. Original was https://github.com/sk89q/worldguard/pull/93
