### PR TITLE
Allow "/region info" for existing but now illegally-named regions.

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
@@ -380,13 +380,12 @@ public class RegionCommands {
             id = args.getString(1).toLowerCase();
         }
         
-        if (!ProtectedRegion.isValidId(id)) {
-            throw new CommandException("Invalid region ID specified!");
-        }
-        
         RegionManager mgr = plugin.getGlobalRegionManager().get(world);
         
         if (!mgr.hasRegion(id)) {
+            if (!ProtectedRegion.isValidId(id)) {
+                throw new CommandException("Invalid region ID specified!");
+            }
             throw new CommandException("A region with ID '" + id + "' doesn't exist.");
         }
 
@@ -409,6 +408,10 @@ public class RegionCommands {
 
         sender.sendMessage(ChatColor.YELLOW + "Region: " + id
                 + ChatColor.GRAY + " (type: " + region.getTypeName() + ")");
+        if (!ProtectedRegion.isValidId(id)) {
+            sender.sendMessage(ChatColor.RED + "This region has an invalid ID. "
+                    + " Please (ask the owner to) delete it and recreate it.");
+        }
         sender.sendMessage(ChatColor.BLUE + "Priority: " + region.getPriority());
 
         StringBuilder s = new StringBuilder();


### PR DESCRIPTION
With the region name validation added in https://github.com/sk89q/worldguard/commit/521ecd438e9bfab8f0195162b516c4335f96bc52, existing regions could fail the new name check, preventing "/region info" working for those regions. I've changed it to show info for those regions, along with a warning about the name. If the user tries to /region info a non-existent invalid-name region, it produces the same error as before.
