### PR TITLE
Add region bounds to "/region info"

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
@@ -434,13 +434,11 @@ public class RegionCommands {
                 + owners.toUserFriendlyString());
         sender.sendMessage(ChatColor.LIGHT_PURPLE + "Members: "
                 + members.toUserFriendlyString());
-        if (plugin.hasPermission(sender, "worldguard.region.bounds")) {
-            BlockVector min = region.getMinimumPoint();
-            BlockVector max = region.getMaximumPoint();
-            String c = "(" + min.getBlockX() + "," + min.getBlockY() + "," + min.getBlockZ() + ")";
-            c += " (" +max.getBlockX() + "," + max.getBlockY() + "," + max.getBlockZ() + ")";
-            sender.sendMessage(ChatColor.LIGHT_PURPLE + "Bounds: " + c);
-        }
+        BlockVector min = region.getMinimumPoint();
+        BlockVector max = region.getMaximumPoint();
+        String c = "(" + min.getBlockX() + "," + min.getBlockY() + "," + min.getBlockZ() + ")";
+        c += " (" +max.getBlockX() + "," + max.getBlockY() + "," + max.getBlockZ() + ")";
+        sender.sendMessage(ChatColor.LIGHT_PURPLE + "Bounds: " + c);
     }
     
     @Command(aliases = {"list"},


### PR DESCRIPTION
Added a line to the bottom of the "/region info" display showing the bounds of the region.
I don't see this as a "security" issue, but some might, so I added a permission for it, "worldguard.region.bounds"; without this permission you won't see the new line.
