### PR TITLE
Config to block fireball world damage

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -96,6 +96,7 @@ public class WorldConfiguration {
     public Set<Integer> allowedLavaSpreadOver;
     public boolean blockCreeperExplosions;
     public boolean blockCreeperBlockDamage;
+    public boolean blockFireballBlockDamage;
     public int loginProtection;
     public int spawnProtection;
     public boolean kickOnDeath;
@@ -275,6 +276,7 @@ public class WorldConfiguration {
 
         blockCreeperExplosions = getBoolean("mobs.block-creeper-explosions", false);
         blockCreeperBlockDamage = getBoolean("mobs.block-creeper-block-damage", false);
+        blockFireballBlockDamage = getBoolean("mobs.block-fireball-block-damage", false);
         antiWolfDumbness = getBoolean("mobs.anti-wolf-dumbness", false);
 
         loginProtection = getInt("spawn.login-protection", 3);

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -484,6 +484,11 @@ public class WorldGuardEntityListener extends EntityListener {
                 }
             }
         } else if (ent instanceof Fireball) {
+        	if (wcfg.blockFireballBlockDamage) {
+        		event.setCancelled(true);
+        		return;
+        	}
+        	
             if (wcfg.useRegions) {
                 Vector pt = toVector(l);
                 RegionManager mgr = plugin.getGlobalRegionManager().get(world);


### PR DESCRIPTION
I noticed that there was a pull request to fix something similar, but this does not quite cover what I need.  I would like explosions to hurt players, but not destroy the things they have created, in a similar way to block-creeper-block-damage.

To that end, I have added a configuration node 'mobs.block-fireball-block-damage' which cancels the explode event in the same way the ghast-fireball region flag does, only without the need for regions.
