### PR TITLE
Fixes missing blocks along some polygonal edges

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -102,6 +102,7 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
         int xOld, zOld;
         int x1, z1;
         int x2, z2;
+        long crossproduct;
         int i;
 
         xOld = points.get(npoints - 1).getBlockX();
@@ -125,10 +126,14 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
                 z1 = zNew;
                 z2 = zOld;
             }
-            if ((xNew < targetX) == (targetX <= xOld)
-                    && ((long) targetZ - (long) z1) * (long) (x2 - x1) <= ((long) z2 - (long) z1)
-                    * (long) (targetX - x1)) {
-                inside = !inside;
+            if (x1 <= targetX && targetX <= x2) {
+                crossproduct = ((long) targetZ - (long) z1) * (long) (x2 - x1)
+                    - ((long) z2 - (long) z1) * (long) (targetX - x1);
+                if (crossproduct == 0) {
+                    if ((z1 <= targetZ) == (targetZ <= z2)) return true; //on edge
+                } else if (crossproduct < 0 && (x1 != targetX)) {
+                    inside = !inside;
+                }
             }
             xOld = xNew;
             zOld = zNew;


### PR DESCRIPTION
In cases where our polygon edge runs exactly horizontal, vertical or perfectly diagonal (1:1); the selection will be missing some blocks along the north (-X) or east (-Z) edge.

This occurs when the cross-product (already computed) is exactly 0. We have to do an extra check to make sure the point is within the bounds of the line on both axis.

_Note: made an identical pull request for the corresponding code in WorldEdit poly region selections._
