### PR TITLE
Fix for ProtectedCuboidRegion->ProtectedCuboidRegion intersection checking 

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
+++ b/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
@@ -145,12 +145,15 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
 
             // Check whether the region is outside the min and max vector
             if ((rMinPoint.getBlockX() < min.getBlockX() && rMaxPoint.getBlockX() < min.getBlockX())
-                            || (rMinPoint.getBlockX() > max.getBlockX() && rMaxPoint.getBlockX() > max.getBlockX())
-                    && ((rMinPoint.getBlockY() < min.getBlockY() && rMaxPoint.getBlockY() < min.getBlockY())
-                            || (rMinPoint.getBlockY() > max.getBlockY() && rMaxPoint.getBlockY() > max.getBlockY()))
-                    && ((rMinPoint.getBlockZ() < min.getBlockZ() && rMaxPoint.getBlockZ() < min.getBlockZ())
-                            || (rMinPoint.getBlockZ() > max.getBlockZ() && rMaxPoint.getBlockZ() > max.getBlockZ())) ) {
-                //intersectingRegions.add(regions.get(i));
+                    || (rMinPoint.getBlockX() > max.getBlockX() && rMaxPoint.getBlockX() > max.getBlockX())
+                    || ((rMinPoint.getBlockY() < min.getBlockY() && rMaxPoint.getBlockY() < min.getBlockY())
+                    || (rMinPoint.getBlockY() > max.getBlockY() && rMaxPoint.getBlockY() > max.getBlockY()))
+                    || ((rMinPoint.getBlockZ() < min.getBlockZ() && rMaxPoint.getBlockZ() < min.getBlockZ())
+                    || (rMinPoint.getBlockZ() > max.getBlockZ() && rMaxPoint.getBlockZ() > max.getBlockZ())) )
+                continue;
+            
+            if (region instanceof ProtectedCuboidRegion) {
+                intersectingRegions.add(regions.get(i));
                 continue;
             }
 
@@ -180,21 +183,6 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
                         intersectingRegions.add(regions.get(i));
                         continue;
                     }
-                }
-            } else if (region instanceof ProtectedCuboidRegion) {
-                BlockVector ptcMin = region.getMinimumPoint();
-                BlockVector ptcMax = region.getMaximumPoint();
-
-                if (this.contains(new Vector(ptcMin.getBlockX(), ptcMin.getBlockY(), ptcMin.getBlockZ()))
-                        || this.contains(new Vector(ptcMin.getBlockX(), ptcMin.getBlockY(), ptcMax.getBlockZ()))
-                        || this.contains(new Vector(ptcMin.getBlockX(), ptcMax.getBlockY(), ptcMax.getBlockZ()))
-                        || this.contains(new Vector(ptcMin.getBlockX(), ptcMax.getBlockY(), ptcMin.getBlockZ()))
-                        || this.contains(new Vector(ptcMax.getBlockX(), ptcMax.getBlockY(), ptcMax.getBlockZ()))
-                        || this.contains(new Vector(ptcMax.getBlockX(), ptcMax.getBlockY(), ptcMin.getBlockZ()))
-                        || this.contains(new Vector(ptcMax.getBlockX(), ptcMin.getBlockY(), ptcMin.getBlockZ()))
-                        || this.contains(new Vector(ptcMax.getBlockX(), ptcMin.getBlockY(), ptcMax.getBlockZ())) ) {
-                    intersectingRegions.add(regions.get(i));
-                    continue;
                 }
             } else {
                 throw new UnsupportedOperationException("Not supported yet.");

--- a/src/test/java/com/sk89q/worldguard/protection/RegionIntersectTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/RegionIntersectTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 public class RegionIntersectTest {
 
     @Test
-    @Ignore
     public void testCuboidGetIntersectingRegions() {
         ProtectedRegion region = new ProtectedCuboidRegion("square",
                 new BlockVector(100, 40, 0), new BlockVector(140, 128, 40));


### PR DESCRIPTION
- Unit tests showcase a failure of the current getIntersectingRegions logic and added a couple other working assertions.
- Added the fix for ProtectedCuboidRegion->ProtectedCuboidRegion intersection checking
- Part of this code fix borrowed from: https://github.com/sk89q/worldguard/pull/111
