### PR TITLE
Peace mode

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/ConfigurationManager.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/ConfigurationManager.java
@@ -77,6 +77,11 @@ public class ConfigurationManager {
     private Set<String> hasGodMode = new HashSet<String>();
 
     /**
+     * List of people with peace mode.
+     */
+    private Set<String> hasPeaceMode = new HashSet<String>();
+
+    /**
      * List of people who can breathe underwater.
      */
     private Set<String> hasAmphibious = new HashSet<String>();
@@ -172,6 +177,7 @@ public class ConfigurationManager {
         }
 
         hasGodMode.remove(player.getName());
+        hasPeaceMode.remove(player.getName());
         hasAmphibious.remove(player.getName());
     }
 
@@ -201,6 +207,34 @@ public class ConfigurationManager {
      */
     public boolean hasGodMode(Player player) {
         return hasGodMode.contains(player.getName());
+    }
+
+    /**
+     * Enable peace mode for a player.
+     *
+     * @param player
+     */
+    public void enablePeaceMode(Player player) {
+        hasPeaceMode.add(player.getName());
+    }
+
+    /**
+     * Disable peace mode for a player.
+     *
+     * @param player
+     */
+    public void disablePeaceMode(Player player) {
+        hasPeaceMode.remove(player.getName());
+    }
+
+    /**
+     * Check to see if peace mode is enabled for a player.
+     *
+     * @param player
+     * @return
+     */
+    public boolean hasPeaceMode(Player player) {
+        return hasPeaceMode.contains(player.getName());
     }
 
     /**

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -56,6 +56,7 @@ import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.entity.EntityListener;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.entity.PigZapEvent;
@@ -117,6 +118,7 @@ public class WorldGuardEntityListener extends EntityListener {
         registerEvent("ENDERMAN_PLACE", Priority.High);
         registerEvent("ENTITY_DEATH", Priority.High);
         registerEvent("FOOD_LEVEL_CHANGE", Priority.High);
+        registerEvent("ENTITY_TARGET", Priority.High);
     }
 
     /**
@@ -864,6 +866,18 @@ public class WorldGuardEntityListener extends EntityListener {
             Player player = (Player) event.getEntity();
             if (event.getFoodLevel() < player.getFoodLevel() && isInvincible(player)) {
                 event.setCancelled(true);
+            }
+        }
+    }
+
+    @Override
+    public void onEntityTarget(EntityTargetEvent event) {
+        ConfigurationManager cfg = plugin.getGlobalStateManager();
+        if (event.getTarget() instanceof Player) {
+            Player player = (Player) event.getTarget();
+            if (event.getReason() == EntityTargetEvent.TargetReason.CLOSEST_PLAYER && cfg.hasPeaceMode(player)) {
+                event.setCancelled(true);
+                
             }
         }
     }

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -179,6 +179,7 @@ public class WorldGuardPlugin extends JavaPlugin {
             if (inGroup(player, "wg-invincible") ||
                     (configuration.autoGodMode && hasPermission(player, "worldguard.auto-invincible"))) {
                 configuration.enableGodMode(player);
+                configuration.enablePeaceMode(player);
             }
         }
 

--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/GeneralCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/GeneralCommands.java
@@ -99,7 +99,7 @@ public class GeneralCommands {
             
             // Check permissions!
             plugin.checkPermission(sender, "worldguard.god");
-        } else if (args.argsLength() == 1) {            
+        } else if (args.argsLength() == 1) {
             targets = plugin.matchPlayers(sender, args.getString(0));
             
             // Check permissions!
@@ -128,7 +128,101 @@ public class GeneralCommands {
             sender.sendMessage(ChatColor.YELLOW.toString() + "Players no longer have god mode.");
         }
     }
+
+    @Command(aliases = {"peace"},
+            usage = "[player]",
+            desc = "Enable peace mode on a player",
+            flags = "s", min = 0, max = 1)
+    public static void peace(CommandContext args, WorldGuardPlugin plugin,
+            CommandSender sender) throws CommandException {
+        ConfigurationManager config = plugin.getGlobalStateManager();
+        
+        Iterable<Player> targets = null;
+        boolean included = false;
+        
+        // Detect arguments based on the number of arguments provided
+        if (args.argsLength() == 0) {
+            targets = plugin.matchPlayers(plugin.checkPlayer(sender));
+            
+            // Check permissions!
+            plugin.checkPermission(sender, "worldguard.god");
+        } else if (args.argsLength() == 1) {
+            targets = plugin.matchPlayers(sender, args.getString(0));
+            
+            // Check permissions!
+            plugin.checkPermission(sender, "worldguard.god.other");
+        }
+
+        for (Player player : targets) {
+            config.enablePeaceMode(player);
+
+            // Tell the user
+            if (player.equals(sender)) {
+                player.sendMessage(ChatColor.YELLOW + "Peace mode enabled! Use /unpeace to disable.");
+                
+                // Keep track of this
+                included = true;
+            } else {
+                player.sendMessage(ChatColor.YELLOW + "Peace enabled by "
+                        + plugin.toName(sender) + ".");
+            }
+        }
+        
+        // The player didn't receive any items, then we need to send the
+        // user a message so s/he know that something is indeed working
+        if (!included && args.hasFlag('s')) {
+            sender.sendMessage(ChatColor.YELLOW.toString() + "Players now have peace mode.");
+        }
+    }
     
+    @Command(aliases = {"unpeace"},
+            usage = "[player]",
+            desc = "Disable peace mode on a player",
+            flags = "s", min = 0, max = 1)
+    public static void unpeace(CommandContext args, WorldGuardPlugin plugin,
+            CommandSender sender) throws CommandException {
+        ConfigurationManager config = plugin.getGlobalStateManager();
+        
+        Iterable<Player> targets = null;
+        boolean included = false;
+        
+        // Detect arguments based on the number of arguments provided
+        if (args.argsLength() == 0) {
+            targets = plugin.matchPlayers(plugin.checkPlayer(sender));
+            
+            // Check permissions!
+            plugin.checkPermission(sender, "worldguard.god");
+        } else if (args.argsLength() == 1) {
+            targets = plugin.matchPlayers(sender, args.getString(0));
+            
+            // Check permissions!
+            plugin.checkPermission(sender, "worldguard.god.other");
+        }
+
+        for (Player player : targets) {
+            config.disablePeaceMode(player);
+            
+            // Tell the user
+            if (player.equals(sender)) {
+                player.sendMessage(ChatColor.YELLOW + "Peace mode disabled!");
+                
+                // Keep track of this
+                included = true;
+            } else {
+                player.sendMessage(ChatColor.YELLOW + "Peace disabled by "
+                        + plugin.toName(sender) + ".");
+                
+            }
+        }
+        
+        // The player didn't receive any items, then we need to send the
+        // user a message so s/he know that something is indeed working
+        if (!included && args.hasFlag('s')) {
+            sender.sendMessage(ChatColor.YELLOW.toString() + "Players no longer have peace mode.");
+        }
+    }
+
+
     @Command(aliases = {"heal"},
             usage = "[player]",
             desc = "Heal a player",

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,6 +18,12 @@ commands:
     ungod:
         description: Disable god mode
         usage: /<command> [player]
+    peace:
+        description: Enable peace mode
+        usage: /<command> [player]
+    unpeace:
+        description: Disable peace mode
+        usage: /<command> [player]
     heal:
         description: Heal yourself or another
         usage: /<command> [player]


### PR DESCRIPTION
A togglable mode, similar to god mode, which prevents hostile mobs from targetting you. No more being attacked or followed, allowing you to get on with your business without distractions, and without having to butcher/kill/disable the mobs. It doesn't affect any mobs that may already be targetting you when you turn it on, and if you attack mobs, they will still respond as usual.
I've used the same permissions as god mode, but if you think someone might want to grant these abilities individually, I can change that. Auto-invincible also enables peace.
It works by cancelling the target event. The mob will try to target again shortly after; it's not a perfect solution, but it works. If you can think of a better way to do it, please tell.
