### PR TITLE
Made explosions display their animations

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -551,7 +551,6 @@ public class WorldGuardEntityListener extends EntityListener {
         World world = l.getWorld();
         WorldConfiguration wcfg = cfg.get(world);
         Entity ent = event.getEntity();
-        List<Block> blocks = event.blockList();
 
         if (cfg.activityHaltToggle) {
             ent.remove();


### PR DESCRIPTION
This is essentially my pull earlier only working. It makes any explosion display even when the block damage is denied.
