### PR TITLE
Inconsistent Permission Fix

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
@@ -524,7 +524,7 @@ public class WorldGuardPlayerListener extends PlayerListener {
             ApplicableRegionSet set = mgr.getApplicableRegions(pt);
             LocalPlayer localPlayer = plugin.wrapPlayer(player);
 
-            if (item.getTypeId() == wcfg.regionWand && player.hasPermission("worldguard.region.wand")) {
+            if (item.getTypeId() == wcfg.regionWand && plugin.hasPermission(player, "worldguard.region.wand")) {
                 if (set.size() > 0) {
                     player.sendMessage(ChatColor.YELLOW + "Can you build? "
                             + (set.canBuild(localPlayer) ? "Yes" : "No"));


### PR DESCRIPTION
This check should be routed through the default permission check like all of the other permission checks.
