### PR TITLE
Fix for bug #728 (Multiverse + Worldguard region with exit flag set)

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
@@ -283,7 +283,6 @@ public class WorldGuardPlayerListener extends PlayerListener {
             if (event.getFrom().getBlockX() != event.getTo().getBlockX()
                     || event.getFrom().getBlockY() != event.getTo().getBlockY()
                     || event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
-		
                 PlayerFlagState state = plugin.getFlagStateManager().getState(player);
                 LocalPlayer localPlayer = plugin.wrapPlayer(player);
                 boolean hasBypass = plugin.getGlobalRegionManager().hasBypass(player, world);


### PR DESCRIPTION
This appears to be working great on my 1.1 server running bukkit 1.1-R3.  A quick clearing of the state if the worlds are different and I don't have the problem anymore.

This is my first contribution to this project so I'm not sure if this effects other stuff but I figure if the player is changing worlds we should be safe in forgetting any region states that currently exist... ??
