### PR TITLE
More limit checks on /region claim

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -120,6 +120,11 @@ public class WorldConfiguration {
     // public boolean buyOnClaim;
     // public double buyOnClaimPrice;
     public int maxClaimVolume;
+    public int maxClaimXLength;
+    public int maxClaimYLength;
+    public int maxClaimZLength;
+    public int minClaimAltitude;
+    public int maxClaimAltitude;
     public boolean claimOnlyInsideExistingRegions;
     public int maxRegionCountPerPlayer;
     public boolean antiWolfDumbness;
@@ -357,6 +362,11 @@ public class WorldConfiguration {
         highFreqFlags = getBoolean("regions.high-frequency-flags", false);
         regionWand = getInt("regions.wand", 287);
         maxClaimVolume = getInt("regions.max-claim-volume", 30000);
+        maxClaimXLength = getInt("regions.max-claim-x-length", 100);
+        maxClaimYLength = getInt("regions.max-claim-y-length", 128);
+        maxClaimZLength = getInt("regions.max-claim-z-length", 100);
+        minClaimAltitude = getInt("regions.min-claim-altitude", 1);
+        maxClaimAltitude = getInt("regions.max-claim-altitude", 128);
         claimOnlyInsideExistingRegions = getBoolean("regions.claim-only-inside-existing-regions", false);
         
         maxRegionCountPerPlayer = getInt("regions.max-region-count-per-player.default", 7);

--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
@@ -323,6 +323,48 @@ public class RegionCommands {
                         "Max. volume: " + wcfg.maxClaimVolume + ", your volume: " + region.volume());
                 return;
             }
+            
+            Vector min = region.getMinimumPoint();
+            Vector max = region.getMaximumPoint();
+            
+            int xLength = max.getBlockX() - min.getBlockX() + 1;
+            int yLength = max.getBlockY() - min.getBlockY() + 1;
+            int zLength = max.getBlockZ() - min.getBlockZ() + 1;
+            
+            if (xLength > wcfg.maxClaimXLength) {
+                player.sendMessage(ChatColor.RED + "This region is too large to claim.");
+                player.sendMessage(ChatColor.RED +
+                        "Max. X length: " + wcfg.maxClaimVolume + ", your X length: " + xLength);
+                return;
+            }
+            
+            if (yLength > wcfg.maxClaimYLength) {
+                player.sendMessage(ChatColor.RED + "This region is too large to claim.");
+                player.sendMessage(ChatColor.RED +
+                        "Max. height: " + wcfg.maxClaimVolume + ", your height: " + yLength);
+                return;
+            }
+            
+            if (zLength > wcfg.maxClaimZLength) {
+                player.sendMessage(ChatColor.RED + "This region is too large to claim.");
+                player.sendMessage(ChatColor.RED +
+                        "Max. Z length: " + wcfg.maxClaimVolume + ", your Z length: " + zLength);
+                return;
+            }
+            
+            if ((max.getBlockY() + 1) > wcfg.maxClaimAltitude) {
+                player.sendMessage(ChatColor.RED + "This region is too high to claim.");
+                player.sendMessage(ChatColor.RED +
+                        "Max. altitude: " + wcfg.maxClaimAltitude + ", your highest altitude: " + (max.getBlockY() + 1));
+                return;
+            }
+            
+            if ((min.getBlockY() + 1) < wcfg.minClaimAltitude) {
+                player.sendMessage(ChatColor.RED + "This region is too low to claim.");
+                player.sendMessage(ChatColor.RED +
+                        "Min. altitude: " + wcfg.maxClaimAltitude + ", your lowest altitude: " + (min.getBlockY() + 1));
+                return;
+            }
         }
 
         region.getOwners().addPlayer(player.getName());


### PR DESCRIPTION
Added a couple extra checks to /region claim.

The first is a maximum x/y/z length.  When only volume is limited, a player can still create something ridiculous like a 300x100x1 region just to cause region conflict troubles for other players.

The second is a minimum/maximum protectable altitude.  Some servers for example don't want players protecting anything below layer 20.
