### PR TITLE
Fixed MySQL database backend/Region_Storage.sql files for new installations, converts db automatically for old installations

### DIFF
--- a/region_storage.sql
+++ b/region_storage.sql
@@ -65,7 +65,7 @@ CREATE  TABLE IF NOT EXISTS `region_flag` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
   `region_id` VARCHAR(128) NOT NULL ,
   `flag` VARCHAR(64) NOT NULL ,
-  `value` VARCHAR(256) NOT NULL ,
+  `value` MEDIUMBLOB NOT NULL ,
   INDEX `fk_flags_region` (`region_id` ASC) ,
   PRIMARY KEY (`id`) ,
   CONSTRAINT `fk_flags_region1`

--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
@@ -671,7 +671,6 @@ public class RegionCommands {
         if (!hasPerm) throw new CommandPermissionsException();
         
         Flag<?> foundFlag = null;
-        
         // Now time to find the flag!
         for (Flag<?> flag : DefaultFlag.getFlags()) {
             // Try to detect the flag
@@ -746,6 +745,7 @@ public class RegionCommands {
                     + "Region group flag for '" + foundFlag.getName() + "' set.");
         } else {
             if (value != null) {
+		Object val;
                 try {
                     setFlag(region, foundFlag, sender, value);
                 } catch (InvalidFlagFormat e) {


### PR DESCRIPTION
Fixed the MySQL backend to actually store the correct flags in the mysql db.
Most important for anything that wasn't a State flag or a String flag, i.e. feed-max-health, or price, etc etc etc.
Automatically detects if the mySQL region_flags table is in the correct format; if not,it tries to parse as many flags as it can and update the table to the new format.. If it is, it adds any flags as a byte array from an object output stream, i.e. no more issues with the "Couldn't parse flag" etc etc for non-State or -String flags.

Next up: a WorldGuard command to convert the old table format to the new table format. /wg fixtables, etc etc.
Should pull in old flags, parse the data correctly, and add it to the new table format.
