### PR TITLE
Added 'allow-flight' boolean flag for regions

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/FlagStateManager.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/FlagStateManager.java
@@ -220,6 +220,7 @@ public class FlagStateManager implements Runnable {
         public Boolean lastExitAllowed = null;
         public Boolean notifiedForLeave = false;
         public Boolean notifiedForEnter = false;
+        public Boolean lastAllowFlight = null;
         public World lastWorld;
         public int lastBlockX;
         public int lastBlockY;

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
@@ -65,6 +65,7 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.GameMode;
 
 /**
  * Handles all events thrown in relation to a player.
@@ -158,6 +159,7 @@ public class WorldGuardPlayerListener implements Listener {
                     String farewell = set.getFlag(DefaultFlag.FAREWELL_MESSAGE);//, localPlayer);
                     Boolean notifyEnter = set.getFlag(DefaultFlag.NOTIFY_ENTER);//, localPlayer);
                     Boolean notifyLeave = set.getFlag(DefaultFlag.NOTIFY_LEAVE);//, localPlayer);
+                    Boolean allowFlight = set.getFlag(DefaultFlag.ALLOW_FLIGHT);//, localPlayer);
 
                     if (state.lastFarewell != null && (farewell == null
                             || !state.lastFarewell.equals(farewell))) {
@@ -196,6 +198,24 @@ public class WorldGuardPlayerListener implements Listener {
                                 + ChatColor.GOLD + " entered NOTIFY region: "
                                 + ChatColor.WHITE
                                 + regionList);
+                    }
+                    
+                    if (allowFlight == null) {
+                        if ((plugin.getServer().getDefaultGameMode() == GameMode.CREATIVE
+                                && player.getGameMode() == GameMode.CREATIVE)
+                                || player.getGameMode() == GameMode.CREATIVE) {
+                            allowFlight = true;
+                        } else {
+                            allowFlight = false;
+                        }
+                    }
+                    
+                    if (player.getAllowFlight() && !allowFlight) {
+                        player.setAllowFlight(false);
+                        state.lastAllowFlight = true;
+                    } else if (!player.getAllowFlight() && allowFlight) {
+                        player.setAllowFlight(true);
+                        state.lastAllowFlight = false;
                     }
 
                     state.lastGreeting = greeting;

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -80,6 +80,7 @@ public final class DefaultFlag {
     public static final DoubleFlag PRICE = new DoubleFlag("price");
     public static final SetFlag<String> BLOCKED_CMDS = new SetFlag<String>("blocked-cmds", RegionGroup.ALL, new CommandStringFlag(null));
     public static final SetFlag<String> ALLOWED_CMDS = new SetFlag<String>("allowed-cmds", RegionGroup.ALL, new CommandStringFlag(null));
+    public static final BooleanFlag ALLOW_FLIGHT = new BooleanFlag("allow-flight", RegionGroup.ALL);
 
     public static final Flag<?>[] flagsList = new Flag<?>[] {
         PASSTHROUGH, BUILD, CONSTRUCT, PVP, CHEST_ACCESS, PISTONS,
@@ -94,7 +95,7 @@ public final class DefaultFlag {
         MUSHROOMS, LEAF_DECAY, GRASS_SPREAD,
         FIRE_SPREAD, LAVA_FIRE, LAVA_FLOW, WATER_FLOW,
         TELE_LOC, SPAWN_LOC,
-        BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE,
+        BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ALLOW_FLIGHT,
     };
 
 


### PR DESCRIPTION
With the new API for flight control added here https://github.com/Bukkit/CraftBukkit/commit/efab19b1b7a812071b2f38e37e4e9ba273971468  and an update here https://github.com/Bukkit/CraftBukkit/commit/82402adbe82ba59ccb27f7a4fea792dac68fcdfa
I tried my hand at adding a region flag to worldguard to control it.
