### PR TITLE
[MySQL] Fix - removing data from tables: region_cuboid and region_players

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/databases/MySQLDatabase.java
+++ b/src/main/java/com/sk89q/worldguard/protection/databases/MySQLDatabase.java
@@ -716,9 +716,23 @@ public class MySQLDatabase extends AbstractProtectionDatabase {
                 PreparedStatement removeRegion = this.conn.prepareStatement(
                         "DELETE FROM `region` WHERE `id` = ? "
                 );
-
                 removeRegion.setString(1, name);
                 removeRegion.execute();
+                
+                // Delete information about the region of the value from the table region_cuboid
+                PreparedStatement removeRegionCuboid = this.conn.prepareStatement(
+                        "DELETE FROM `region_cuboid` WHERE `region_id` = ? "
+                );
+                removeRegionCuboid.setString(1, name);
+                removeRegionCuboid.execute();
+                
+                // Delete information about the region of the value from the table region_players
+                PreparedStatement removeRegionPlayers = this.conn.prepareStatement(
+                        "DELETE FROM `region_players` WHERE `region_id` = ? "
+                );
+                removeRegionPlayers.setString(1, name);
+                removeRegionPlayers.execute();
+                
             } catch (SQLException ex) {
                 logger.warning("Could not remove region from database " + name + ": " + ex.getMessage());
             }


### PR DESCRIPTION
Removing the region did not remove his data from the tables: region_cuboid and region_players. Maybe the code needs to be further optimized.
I am sorry if something is wrong.
