### PR TITLE
Saturation support for /heal

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/GeneralCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/GeneralCommands.java
@@ -152,6 +152,7 @@ public class GeneralCommands {
         for (Player player : targets) {
             player.setHealth(20);
             player.setFoodLevel(20);
+            player.setSaturation(20.0f);
             
             // Tell the user
             if (player.equals(sender)) {


### PR DESCRIPTION
Simple saturation support for /heal, makes it so you dont lose hunger as soon as you /heal
