### PR TITLE
Allow spawning of creatures from plugins

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -98,6 +98,7 @@ public class WorldConfiguration {
     public boolean blockFireballExplosions;
     public boolean blockFireballBlockDamage;
     public boolean blockEntityPaintingDestroy;
+    public boolean blockPluginSpawning;
     public boolean disableContactDamage;
     public boolean disableFallDamage;
     public boolean disableLavaDamage;
@@ -315,6 +316,7 @@ public class WorldConfiguration {
         antiWolfDumbness = getBoolean("mobs.anti-wolf-dumbness", false);
         disableEndermanGriefing = getBoolean("mobs.disable-enderman-griefing", false);
         blockEntityPaintingDestroy = getBoolean("mobs.block-painting-destroy", false);
+        blockPluginSpawning = getBoolean("mobs.block-plugin-spawning", true);
 
         disableFallDamage = getBoolean("player-damage.disable-fall-damage", false);
         disableLavaDamage = getBoolean("player-damage.disable-lava-damage", false);

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -610,6 +610,11 @@ public class WorldGuardEntityListener implements Listener {
         }
 
         WorldConfiguration wcfg = cfg.get(event.getEntity().getWorld());
+
+        // allow spawning of creatures from plugins
+        if (!wcfg.blockPluginSpawning && event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.CUSTOM)
+            return;
+
         EntityType entityType = event.getEntityType();
 
         if (wcfg.blockCreatureSpawn.contains(entityType)) {


### PR DESCRIPTION
Mob spawning should only be denied for natural spawning of mobs.  Mobs spawned by plugins would be allowed, and should be up to the plugin author to decide if they need to respect WorldGuard region flags.
