### PR TITLE
"texture-pack" region flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
       <version>1.3.2-R1.0</version>
     </dependency>
 
+    <!-- CraftBukkit (workaround for texture-pack flag until Bukkit adds proper API) -->
+    <dependency>
+      <groupId>org.bukkit</groupId>
+      <artifactId>craftbukkit</artifactId>
+      <version>1.3.2-R1.0</version>
+    </dependency>
+
     <!-- CommandBook -->
     <dependency>
       <groupId>com.sk89q</groupId>

--- a/src/main/java/com/sk89q/worldguard/bukkit/FlagStateManager.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/FlagStateManager.java
@@ -217,6 +217,7 @@ public class FlagStateManager implements Runnable {
         public long lastFeed;
         public String lastGreeting;
         public String lastFarewell;
+        public String lastTexture;
         public Boolean lastExitAllowed = null;
         public Boolean notifiedForLeave = false;
         public Boolean notifiedForEnter = false;

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
@@ -160,6 +160,7 @@ public class WorldGuardPlayerListener implements Listener {
 
                     String greeting = set.getFlag(DefaultFlag.GREET_MESSAGE);//, localPlayer);
                     String farewell = set.getFlag(DefaultFlag.FAREWELL_MESSAGE);//, localPlayer);
+                    String texture = set.getFlag(DefaultFlag.TEXTURE_PACK);
                     Boolean notifyEnter = set.getFlag(DefaultFlag.NOTIFY_ENTER);//, localPlayer);
                     Boolean notifyLeave = set.getFlag(DefaultFlag.NOTIFY_LEAVE);//, localPlayer);
                     GameMode gameMode = set.getFlag(DefaultFlag.GAME_MODE);
@@ -180,6 +181,11 @@ public class WorldGuardPlayerListener implements Listener {
                         for (String line : replacedGreeting.split("\n")) {
                             player.sendMessage(ChatColor.AQUA + " ** " + line);
                         }
+                    }
+
+                    if (texture != null && (state.lastTexture == null
+                            || !state.lastTexture.equals(texture))) {
+                            plugin.switchTexturePack(player, texture);
                     }
 
                     if ((notifyLeave == null || !notifyLeave)
@@ -224,6 +230,7 @@ public class WorldGuardPlayerListener implements Listener {
 
                     state.lastGreeting = greeting;
                     state.lastFarewell = farewell;
+                    state.lastTexture = texture;
                     state.notifiedForEnter = notifyEnter;
                     state.notifiedForLeave = notifyLeave;
                     state.lastExitAllowed = exitAllowed;

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -57,6 +57,12 @@ import com.sk89q.worldguard.protection.GlobalRegionManager;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.util.FatalConfigurationLoadingException;
 
+// These imports from CraftBukkit/Minecraft are a workaround for implementing
+// the "texture-pack" region flag. Once Bukkit supports a proper API, these can
+// be removed.
+import net.minecraft.server.Packet250CustomPayload;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+
 /**
  * The main class for WorldGuard as a Bukkit plugin.
  *
@@ -847,5 +853,21 @@ public class WorldGuardPlugin extends JavaPlugin {
         }
 
         return message;
+    }
+
+    /**
+     * Switch texture packs on the client.
+     *
+     * Sends a texture pack URL to the client using the builtin "MC|TPack"
+     * plugin channel. The client will then download the texture pack and
+     * automatically switch to it.
+     *
+     * @param player Switch texture pack in this player's client.
+     * @param url URL from which to download the texture pack. Must use
+     * only US-ASCII characters.
+     */
+    public void switchTexturePack(Player player, String url) {
+        byte[] message = (url + "\0" + "16").getBytes();
+        ((CraftPlayer)player).getHandle().netServerHandler.sendPacket(new Packet250CustomPayload("MC|TPack", message));
     }
 }

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardVehicleListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardVehicleListener.java
@@ -121,6 +121,7 @@ public class WorldGuardVehicleListener implements Listener {
 
                 String greeting = set.getFlag(DefaultFlag.GREET_MESSAGE, localPlayer);
                 String farewell = set.getFlag(DefaultFlag.FAREWELL_MESSAGE, localPlayer);
+                String texture = set.getFlag(DefaultFlag.TEXTURE_PACK);
                 Boolean notifyEnter = set.getFlag(DefaultFlag.NOTIFY_ENTER, localPlayer);
                 Boolean notifyLeave = set.getFlag(DefaultFlag.NOTIFY_LEAVE, localPlayer);
 
@@ -136,6 +137,11 @@ public class WorldGuardVehicleListener implements Listener {
                     String replacedGreeting = plugin.replaceMacros(
                             player, BukkitUtil.replaceColorMacros(greeting));
                     player.sendMessage(ChatColor.AQUA + " ** " + replacedGreeting);
+                }
+
+                if (texture != null && (state.lastTexture == null
+                        || !state.lastTexture.equals(texture))) {
+                        plugin.switchTexturePack(player, texture);
                 }
 
                 if ((notifyLeave == null || !notifyLeave)
@@ -165,6 +171,7 @@ public class WorldGuardVehicleListener implements Listener {
 
                 state.lastGreeting = greeting;
                 state.lastFarewell = farewell;
+                state.lastTexture = texture;
                 state.notifiedForEnter = notifyEnter;
                 state.notifiedForLeave = notifyLeave;
                 state.lastExitAllowed = exitAllowed;

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -69,6 +69,7 @@ public final class DefaultFlag {
     public static final StateFlag POTION_SPLASH = new StateFlag("potion-splash", true);
     public static final StringFlag GREET_MESSAGE = new StringFlag("greeting", RegionGroup.ALL);
     public static final StringFlag FAREWELL_MESSAGE = new StringFlag("farewell", RegionGroup.ALL);
+    public static final StringFlag TEXTURE_PACK = new StringFlag("texture-pack", RegionGroup.ALL);
     public static final BooleanFlag NOTIFY_ENTER = new BooleanFlag("notify-enter", RegionGroup.ALL);
     public static final BooleanFlag NOTIFY_LEAVE = new BooleanFlag("notify-leave", RegionGroup.ALL);
     public static final SetFlag<EntityType> DENY_SPAWN = new SetFlag<EntityType>("deny-spawn", RegionGroup.ALL, new EntityTypeFlag(null));
@@ -93,7 +94,7 @@ public final class DefaultFlag {
         TNT, LIGHTER, USE, PLACE_VEHICLE, DESTROY_VEHICLE, SLEEP,
         MOB_DAMAGE, MOB_SPAWNING, DENY_SPAWN, INVINCIBILITY, EXP_DROPS,
         CREEPER_EXPLOSION, ENDERDRAGON_BLOCK_DAMAGE, GHAST_FIREBALL, ENDER_BUILD,
-        GREET_MESSAGE, FAREWELL_MESSAGE, NOTIFY_ENTER, NOTIFY_LEAVE,
+        GREET_MESSAGE, FAREWELL_MESSAGE, TEXTURE_PACK, NOTIFY_ENTER, NOTIFY_LEAVE,
         EXIT, ENTRY, LIGHTNING, ENTITY_PAINTING_DESTROY, ITEM_DROP,
         HEAL_AMOUNT, HEAL_DELAY, MIN_HEAL, MAX_HEAL,
         FEED_DELAY, FEED_AMOUNT, MIN_FOOD, MAX_FOOD,


### PR DESCRIPTION
Implemented "texture-pack" region flag.

This implements a "texture-pack" region flag which will switch
textures in the Minecraft client as the user moves into a region
with this flag defined.

The current implementation adds a Maven dependency to CraftBukkit to
access the base Minecraft and CraftBukkit server classes, because
CraftPlayer.sendPluginMessage() does not support sending to the
internal Minecraft channels.
For details see: http://bukkit.atlassian.net/browse/BUKKIT-2579
