### PR TITLE
Fix spurious leading comma in "Flags:" header shown with "/region info"

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
@@ -495,7 +495,7 @@ public class RegionCommands {
                 continue;
             }
 
-            if (s.length() > 0) {
+            if (hasFlags) {
                 s.append(", ");
             }
 


### PR DESCRIPTION
When the "/region info" command displays any flags in the region, it always prints an extra leading comma character after the "Flags:" prompt. It's literally a one word fix. Here's an image to illustrate what I mean:

![Screenshot](http://lh4.googleusercontent.com/-k79ZD_FtKVM/UIT0LjIxfvI/AAAAAAAAA3M/BxNZwmWHTxk/s854/2012-10-21_22.40.22.png)
