### PR TITLE
Fixed bugs in the PRTreeRegionManager

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/managers/PRTreeRegionManager.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/PRTreeRegionManager.java
@@ -18,24 +18,19 @@
  */
 package com.sk89q.worldguard.protection.managers;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.databases.ProtectionDatabase;
+import com.sk89q.worldguard.protection.databases.ProtectionDatabaseException;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.ProtectedRegionMBRConverter;
 import org.khelekore.prtree.MBR;
 import org.khelekore.prtree.MBRConverter;
 import org.khelekore.prtree.PRTree;
 import org.khelekore.prtree.SimpleMBR;
 
-import com.sk89q.worldedit.Vector;
-import com.sk89q.worldguard.LocalPlayer;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.databases.ProtectionDatabaseException;
-import com.sk89q.worldguard.protection.databases.ProtectionDatabase;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import com.sk89q.worldguard.protection.regions.ProtectedRegionMBRConverter;
+import java.util.*;
 
 public class PRTreeRegionManager extends RegionManager {
 
@@ -109,18 +104,21 @@ public class PRTreeRegionManager extends RegionManager {
             }
         }
 
-    tree = new PRTree<ProtectedRegion>(converter, BRANCH_FACTOR);
+        tree = new PRTree<ProtectedRegion>(converter, BRANCH_FACTOR);
         tree.load(regions.values());
     }
 
     @Override
     public ApplicableRegionSet getApplicableRegions(Vector pt) {
-        List<ProtectedRegion> appRegions =
-                new ArrayList<ProtectedRegion>();
+
+        // Floor the vector to ensure we get accurate points
+        pt = pt.floor();
+
+        List<ProtectedRegion> appRegions = new ArrayList<ProtectedRegion>();
         MBR pointMBR = new SimpleMBR(pt.getX(), pt.getX(), pt.getY(), pt.getY(), pt.getZ(), pt.getZ());
 
         for (ProtectedRegion region : tree.find(pointMBR)) {
-            if (region.contains(pt)) {
+            if (region.contains(pt) && !appRegions.contains(region)) {
                 appRegions.add(region);
 
                 ProtectedRegion parent = region.getParent();
@@ -157,12 +155,26 @@ public class PRTreeRegionManager extends RegionManager {
 
     @Override
     public List<String> getApplicableRegionsIDs(Vector pt) {
+
+        // Floor the vector to ensure we get accurate points
+        pt = pt.floor();
+
         List<String> applicable = new ArrayList<String>();
         MBR pointMBR = new SimpleMBR(pt.getX(), pt.getX(), pt.getY(), pt.getY(), pt.getZ(), pt.getZ());
 
         for (ProtectedRegion region : tree.find(pointMBR)) {
-            if (region.contains(pt)) {
+            if (region.contains(pt) && !applicable.contains(region.getId())) {
                 applicable.add(region.getId());
+
+                ProtectedRegion parent = region.getParent();
+
+                while (parent != null) {
+                    if (!applicable.contains(parent.getId())) {
+                        applicable.add(parent.getId());
+                    }
+
+                    parent = parent.getParent();
+                }
             }
         }
 


### PR DESCRIPTION
- Point would not be returned if the player was at point which exceeded the flat decimal maximum of a region.
- The getAplicableRegionIDs method would not return the parents of a region.
