### PR TITLE
Improvements to /region info|flag with -g group flag handling

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionCommands.java
@@ -798,6 +798,12 @@ public class RegionCommands {
             // Clear the flag only if neither [value] nor [-g group] was given
             region.setFlag(foundFlag, null);
 
+            // Also clear the associated group flag if one exists
+            RegionGroupFlag groupFlag = foundFlag.getRegionGroupFlag();
+            if (groupFlag != null) {
+                region.setFlag(groupFlag, null);
+            }
+
             sender.sendMessage(ChatColor.YELLOW
                     + "Region flag '" + foundFlag.getName() + "' cleared.");
         }


### PR DESCRIPTION
I've made some improvements with how the -g flag is displayed with /region info and how it can be changed with /region flag. Each improvement is a separate commit in this pull request for easier reviewing. The issues I've noticed and fixed are:

1) The /region info command wasn't showing the group flags at all (they aren't in the DefaultFlag.getFlags() list).

2) The /region flag command with -g didn't allow you to unset the flag since -g always requires an argument. Now you can unset it by specifying the default group value.

3) The usage statement for /region flag seemed to imply that you can set both the group and the flag value at once, when in fact it would ignore the flag value in this special case. Now this works as expected. If there's a parse error in either the group or value, the whole command aborts with no changes made.

4) If a flag is deleted by setting it to empty, the corresponding group flag is automatically deleted. Otherwise the next time the user sets the same flag again, they might be surprised to all of a sudden see the group flag appear again because it was still in the database.

Below is a chat transcript that illustrates what some of these features look like:

<pre>
/region info testing
Region: testing, type: cuboid, Priority: 0
Flags: greeting: Hello, farewell: Goodbye, entry -g ALL: ALLOW
Owners: thvortex
Bounds: (-84,0,245) (-82,255,249)
/region flag testing entry -g owners deny
Region flag 'entry' set.
Region group flag for 'entry' set.
/region info testing
Region: testing, type: cuboid, Priority: 0
Flags: greeting: Hello, farewell: Goodbye, entry -g OWNERS: DENY
Owners: thvortex
Bounds: (-84,0,245) (-82,255,249)
/region flag testing entry -g non_members
Region group flag for 'entry' reset to default.
/region info testing
Region: testing, type: cuboid, Priority: 0
Flags: greeting: Hello, farewell: Goodbye, entry: DENY
Owners: thvortex
Bounds: (-84,0,245) (-82,255,249)
</pre>
