### PR TITLE
Added support for more wither-related protections.

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -95,7 +95,10 @@ public class WorldConfiguration {
     public boolean blockTNTBlockDamage;
     public boolean blockCreeperExplosions;
     public boolean blockCreeperBlockDamage;
+    public boolean blockWitherExplosions;
     public boolean blockWitherBlockDamage;
+    public boolean blockWitherSkullExplosions;
+    public boolean blockWitherSkullBlockDamage;
     public boolean blockEnderDragonBlockDamage;
     public boolean blockFireballExplosions;
     public boolean blockFireballBlockDamage;
@@ -312,7 +315,10 @@ public class WorldConfiguration {
 
         blockCreeperExplosions = getBoolean("mobs.block-creeper-explosions", false);
         blockCreeperBlockDamage = getBoolean("mobs.block-creeper-block-damage", false);
+        blockWitherExplosions = getBoolean("mobs.block-wither-explosions", false);
         blockWitherBlockDamage = getBoolean("mobs.block-wither-block-damage", false);
+        blockWitherSkullExplosions = getBoolean("mobs.block-wither-skull-explosions", false);
+        blockWitherSkullBlockDamage = getBoolean("mobs.block-wither-skull-block-damage", false);
         blockEnderDragonBlockDamage = getBoolean("mobs.block-enderdragon-block-damage", false);
         blockFireballExplosions = getBoolean("mobs.block-fireball-explosions", false);
         blockFireballBlockDamage = getBoolean("mobs.block-fireball-block-damage", false);

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -42,6 +42,7 @@ import org.bukkit.entity.Skeleton;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Wither;
+import org.bukkit.entity.WitherSkull;
 import org.bukkit.entity.Wolf;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -496,6 +497,23 @@ public class WorldGuardEntityListener implements Listener {
                 event.blockList().clear();
                 return;
             }
+
+            if (wcfg.blockWitherExplosions) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+
+        if (ent instanceof WitherSkull) {
+            if (wcfg.blockWitherSkullBlockDamage) {
+                event.blockList().clear();
+                return;
+            }
+
+            if (wcfg.blockWitherSkullExplosions) {
+                event.setCancelled(true);
+                return;
+            }
         }
 
         if (ent instanceof Creeper) {
@@ -608,12 +626,35 @@ public class WorldGuardEntityListener implements Listener {
         }
         
         if (event.getEntityType() == EntityType.WITHER) {
-            if (wcfg.blockWitherBlockDamage) {
+            if (wcfg.blockWitherExplosions) {
                 event.setCancelled(true);
                 return;
             }
         }
-
+        else if (event.getEntityType() == EntityType.WITHER_SKULL) {
+            if (wcfg.blockWitherSkullExplosions) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        else if (event.getEntityType() == EntityType.LARGE_FIREBALL) {
+            if (wcfg.blockFireballExplosions) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        else if (event.getEntityType() == EntityType.CREEPER) {
+            if (wcfg.blockCreeperExplosions) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        else if (event.getEntityType() == EntityType.PRIMED_TNT) {
+            if (wcfg.blockTNTExplosions) {
+                event.setCancelled(true);
+                return;
+            }
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)


### PR DESCRIPTION
This commit adds the ability to protect against the block damage caused by wither skulls. It also adds support to block the explosions caused by both withers and wither skulls. It also fixes the broken settings that supposedly blocked fireball, creeper, and TNT explosions.
