### PR TITLE
implement the new hanging events (second try)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.4.2-R0.1-SNAPSHOT</version>
+      <version>1.4.2-R0.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/sk89q/worldguard/bukkit/BukkitUtil.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/BukkitUtil.java
@@ -253,4 +253,18 @@ public class BukkitUtil {
                     && !(entity instanceof Tameable)
                     && !(entity instanceof Player));
     }
+
+    /**
+     * Returns whether our running CraftBukkit already supports
+     * the HangingEvent instead of the PaintingEvent
+     *
+     * @return
+     */
+    public static boolean hasHangingEvent() {
+        Class<?> tmp = null;
+        try {
+            tmp = Class.forName("org.bukkit.event.hanging.HangingEvent");
+        } catch (ClassNotFoundException ex) { }
+        return (tmp != null);
+    }
 }

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -103,6 +103,7 @@ public class WorldConfiguration {
     public boolean blockFireballExplosions;
     public boolean blockFireballBlockDamage;
     public boolean blockEntityPaintingDestroy;
+    public boolean blockEntityItemFrameDestroy;
     public boolean blockPluginSpawning;
     public boolean disableContactDamage;
     public boolean disableFallDamage;
@@ -325,6 +326,7 @@ public class WorldConfiguration {
         antiWolfDumbness = getBoolean("mobs.anti-wolf-dumbness", false);
         disableEndermanGriefing = getBoolean("mobs.disable-enderman-griefing", false);
         blockEntityPaintingDestroy = getBoolean("mobs.block-painting-destroy", false);
+        blockEntityItemFrameDestroy = getBoolean("mobs.block-item-frame-destroy", false);
         blockPluginSpawning = getBoolean("mobs.block-plugin-spawning", true);
 
         disableFallDamage = getBoolean("player-damage.disable-fall-damage", false);

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -35,7 +35,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Skeleton;
@@ -64,16 +63,11 @@ import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.entity.PigZapEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
-import org.bukkit.event.painting.PaintingBreakByEntityEvent;
-import org.bukkit.event.painting.PaintingBreakEvent;
-import org.bukkit.event.painting.PaintingPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.blocks.BlockID;
-import com.sk89q.worldedit.blocks.ItemID;
 import com.sk89q.worldguard.LocalPlayer;
-import com.sk89q.worldguard.blacklist.events.BlockBreakBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemUseBlacklistEvent;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.GlobalRegionManager;
@@ -725,88 +719,6 @@ public class WorldGuardEntityListener implements Listener {
 
         if (wcfg.disableCreeperPower) {
             event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    public void onPaintingBreak(PaintingBreakEvent breakEvent) {
-        if (!(breakEvent instanceof PaintingBreakByEntityEvent)) {
-            return;
-        }
-
-        PaintingBreakByEntityEvent event = (PaintingBreakByEntityEvent) breakEvent;
-        Painting painting = event.getPainting();
-        World world = painting.getWorld();
-        ConfigurationManager cfg = plugin.getGlobalStateManager();
-        WorldConfiguration wcfg = cfg.get(world);
-
-        if (event.getRemover() instanceof Player) {
-            Player player = (Player) event.getRemover();
-
-
-            if (wcfg.getBlacklist() != null) {
-                if (!wcfg.getBlacklist().check(
-                        new BlockBreakBlacklistEvent(plugin.wrapPlayer(player),
-                                toVector(player.getLocation()), ItemID.PAINTING), false, false)) {
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-
-            if (wcfg.useRegions) {
-                if (!plugin.getGlobalRegionManager().canBuild(player, painting.getLocation())) {
-                    player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-        } else {
-            if (event.getRemover() instanceof Creeper) {
-                if (wcfg.blockCreeperBlockDamage || wcfg.blockCreeperExplosions) {
-                    event.setCancelled(true);
-                    return;
-                }
-                if (wcfg.useRegions && !plugin.getGlobalRegionManager().allows(DefaultFlag.CREEPER_EXPLOSION, painting.getLocation())) {
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-
-            if (wcfg.blockEntityPaintingDestroy) {
-                event.setCancelled(true);
-                return;
-            }
-            if (wcfg.useRegions && !plugin.getGlobalRegionManager().allows(DefaultFlag.ENTITY_PAINTING_DESTROY, painting.getLocation())) {
-                event.setCancelled(true);
-                return;
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    public void onPaintingPlace(PaintingPlaceEvent event) {
-        Block placedOn = event.getBlock();
-        Player player = event.getPlayer();
-        World world = placedOn.getWorld();
-
-        ConfigurationManager cfg = plugin.getGlobalStateManager();
-        WorldConfiguration wcfg = cfg.get(world);
-
-        if (wcfg.getBlacklist() != null) {
-            if (!wcfg.getBlacklist().check(
-                    new ItemUseBlacklistEvent(plugin.wrapPlayer(player),
-                            toVector(player.getLocation()), ItemID.PAINTING), false, false)) {
-                event.setCancelled(true);
-                return;
-            }
-        }
-
-        if (wcfg.useRegions) {
-            if (!plugin.getGlobalRegionManager().canBuild(player, placedOn.getLocation())) {
-                player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
-                event.setCancelled(true);
-                return;
-            }
         }
     }
 

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardHangingListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardHangingListener.java
@@ -1,0 +1,148 @@
+package com.sk89q.worldguard.bukkit;
+
+import static com.sk89q.worldguard.bukkit.BukkitUtil.toVector;
+
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Hanging;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Painting;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.hanging.HangingBreakByEntityEvent;
+import org.bukkit.event.hanging.HangingBreakEvent;
+import org.bukkit.event.hanging.HangingPlaceEvent;
+
+import com.sk89q.worldedit.blocks.ItemID;
+import com.sk89q.worldguard.blacklist.events.BlockBreakBlacklistEvent;
+import com.sk89q.worldguard.blacklist.events.ItemUseBlacklistEvent;
+import com.sk89q.worldguard.protection.flags.DefaultFlag;
+
+/**
+ * Listener for painting related events.
+ *
+ * @author BangL <henno.rickowski@gmail.com>
+ */
+public class WorldGuardHangingListener implements Listener {
+
+    private WorldGuardPlugin plugin;
+
+    /**
+     * Construct the object;
+     *
+     * @param plugin The plugin instance
+     */
+    public WorldGuardHangingListener(WorldGuardPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Register events.
+     */
+    public void registerEvents() {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onHangingingBreak(HangingBreakEvent breakEvent) {
+        if (!(breakEvent instanceof HangingBreakByEntityEvent)) {
+            return;
+        }
+
+        HangingBreakByEntityEvent event = (HangingBreakByEntityEvent) breakEvent;
+        Hanging hanging = event.getEntity();
+        World world = hanging.getWorld();
+        ConfigurationManager cfg = plugin.getGlobalStateManager();
+        WorldConfiguration wcfg = cfg.get(world);
+
+        if (event.getRemover() instanceof Player) {
+            Player player = (Player) event.getRemover();
+
+            if (wcfg.getBlacklist() != null) {
+                if (hanging instanceof Painting
+                        && !wcfg.getBlacklist().check(
+                            new BlockBreakBlacklistEvent(plugin.wrapPlayer(player),
+                                    toVector(player.getLocation()), ItemID.PAINTING), false, false)) {
+                    event.setCancelled(true);
+                    return;
+                } else if (hanging instanceof ItemFrame
+                        && !wcfg.getBlacklist().check(
+                            new BlockBreakBlacklistEvent(plugin.wrapPlayer(player),
+                                    toVector(player.getLocation()), ItemID.ITEM_FRAME), false, false)) {
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            if (wcfg.useRegions) {
+                if (!plugin.getGlobalRegionManager().canBuild(player, hanging.getLocation())) {
+                    player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+        } else {
+            if (event.getRemover() instanceof Creeper) {
+                if (wcfg.blockCreeperBlockDamage || wcfg.blockCreeperExplosions) {
+                    event.setCancelled(true);
+                    return;
+                }
+                if (wcfg.useRegions && !plugin.getGlobalRegionManager().allows(DefaultFlag.CREEPER_EXPLOSION, hanging.getLocation())) {
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            if (hanging instanceof Painting
+                    && (wcfg.blockEntityPaintingDestroy
+                    || (wcfg.useRegions
+                    && !plugin.getGlobalRegionManager().allows(DefaultFlag.ENTITY_PAINTING_DESTROY, hanging.getLocation())))) {
+                event.setCancelled(true);
+            } else if (hanging instanceof ItemFrame
+                    && (wcfg.blockEntityItemFrameDestroy
+                    || (wcfg.useRegions
+                    && !plugin.getGlobalRegionManager().allows(DefaultFlag.ENTITY_ITEM_FRAME_DESTROY, hanging.getLocation())))) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onHangingPlace(HangingPlaceEvent event) {
+        Block placedOn = event.getBlock();
+        Player player = event.getPlayer();
+        World world = placedOn.getWorld();
+
+        ConfigurationManager cfg = plugin.getGlobalStateManager();
+        WorldConfiguration wcfg = cfg.get(world);
+
+        if (wcfg.getBlacklist() != null) {
+
+            if (event.getEntity() instanceof Painting
+                    && !wcfg.getBlacklist().check(
+                        new ItemUseBlacklistEvent(plugin.wrapPlayer(player),
+                                toVector(player.getLocation()), ItemID.PAINTING), false, false)) {
+                event.setCancelled(true);
+                return;
+            } else if (event.getEntity() instanceof ItemFrame
+                    && !wcfg.getBlacklist().check(
+                        new ItemUseBlacklistEvent(plugin.wrapPlayer(player),
+                                toVector(player.getLocation()), ItemID.ITEM_FRAME), false, false)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+
+        if (wcfg.useRegions) {
+            if (!plugin.getGlobalRegionManager().canBuild(player, placedOn.getLocation())) {
+                player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPaintingListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPaintingListener.java
@@ -1,0 +1,130 @@
+package com.sk89q.worldguard.bukkit;
+
+import static com.sk89q.worldguard.bukkit.BukkitUtil.toVector;
+
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Painting;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.painting.PaintingBreakByEntityEvent;
+import org.bukkit.event.painting.PaintingBreakEvent;
+import org.bukkit.event.painting.PaintingPlaceEvent;
+
+import com.sk89q.worldedit.blocks.ItemID;
+import com.sk89q.worldguard.blacklist.events.BlockBreakBlacklistEvent;
+import com.sk89q.worldguard.blacklist.events.ItemUseBlacklistEvent;
+import com.sk89q.worldguard.protection.flags.DefaultFlag;
+import org.bukkit.Warning;
+
+/**
+ * Listener for painting related events.
+ *
+ * @author sk89q
+ * @deprecated Use {@link com.sk89q.worldguard.bukkit.WorldGuardHangingListener} instead.
+ */
+@Deprecated
+@Warning(reason="This listener has been replaced by WorldGuardHangingListener")
+public class WorldGuardPaintingListener implements Listener {
+
+    private WorldGuardPlugin plugin;
+
+    /**
+     * Construct the object;
+     *
+     * @param plugin The plugin instance
+     */
+    public WorldGuardPaintingListener(WorldGuardPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Register events.
+     */
+    public void registerEvents() {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPaintingBreak(PaintingBreakEvent breakEvent) {
+        if (!(breakEvent instanceof PaintingBreakByEntityEvent)) {
+            return;
+        }
+
+        PaintingBreakByEntityEvent event = (PaintingBreakByEntityEvent) breakEvent;
+        Painting painting = event.getPainting();
+        World world = painting.getWorld();
+        ConfigurationManager cfg = plugin.getGlobalStateManager();
+        WorldConfiguration wcfg = cfg.get(world);
+
+        if (event.getRemover() instanceof Player) {
+            Player player = (Player) event.getRemover();
+
+            if (wcfg.getBlacklist() != null) {
+                if (!wcfg.getBlacklist().check(
+                            new BlockBreakBlacklistEvent(plugin.wrapPlayer(player),
+                                    toVector(player.getLocation()), ItemID.PAINTING), false, false)) {
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            if (wcfg.useRegions) {
+                if (!plugin.getGlobalRegionManager().canBuild(player, painting.getLocation())) {
+                    player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+        } else {
+            if (event.getRemover() instanceof Creeper) {
+                if (wcfg.blockCreeperBlockDamage || wcfg.blockCreeperExplosions) {
+                    event.setCancelled(true);
+                    return;
+                }
+                if (wcfg.useRegions && !plugin.getGlobalRegionManager().allows(DefaultFlag.CREEPER_EXPLOSION, painting.getLocation())) {
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            if (wcfg.blockEntityPaintingDestroy
+                    || (wcfg.useRegions
+                    && !plugin.getGlobalRegionManager().allows(DefaultFlag.ENTITY_PAINTING_DESTROY, painting.getLocation()))) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPaintingPlace(PaintingPlaceEvent event) {
+        Block placedOn = event.getBlock();
+        Player player = event.getPlayer();
+        World world = placedOn.getWorld();
+
+        ConfigurationManager cfg = plugin.getGlobalStateManager();
+        WorldConfiguration wcfg = cfg.get(world);
+
+        if (wcfg.getBlacklist() != null) {
+
+            if (!wcfg.getBlacklist().check(
+                    new ItemUseBlacklistEvent(plugin.wrapPlayer(player),
+                            toVector(player.getLocation()), ItemID.PAINTING), false, false)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+
+        if (wcfg.useRegions) {
+            if (!plugin.getGlobalRegionManager().canBuild(player, placedOn.getLocation())) {
+                player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldguard.bukkit;
 
+import static com.sk89q.worldguard.bukkit.BukkitUtil.hasHangingEvent;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -160,6 +162,11 @@ public class WorldGuardPlugin extends JavaPlugin {
         (new WorldGuardWeatherListener(this)).registerEvents();
         (new WorldGuardVehicleListener(this)).registerEvents();
         (new WorldGuardServerListener(this)).registerEvents();
+        if (hasHangingEvent()) {
+            (new WorldGuardHangingListener(this)).registerEvents();
+        } else {
+            (new WorldGuardPaintingListener(this)).registerEvents();
+        }
         configuration.updateCommandBookGodMode();
 
         if (getServer().getPluginManager().isPluginEnabled("CommandBook")) {

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -66,6 +66,7 @@ public final class DefaultFlag {
     public static final StateFlag EXIT = new StateFlag("exit", true);
     public static final StateFlag ITEM_DROP = new StateFlag("item-drop", true);
     public static final StateFlag ENTITY_PAINTING_DESTROY = new StateFlag("entity-painting-destroy", true);
+    public static final StateFlag ENTITY_ITEM_FRAME_DESTROY = new StateFlag("entity-item-frame-destroy", true);
     public static final StateFlag POTION_SPLASH = new StateFlag("potion-splash", true);
     public static final StringFlag GREET_MESSAGE = new StringFlag("greeting", RegionGroup.ALL);
     public static final StringFlag FAREWELL_MESSAGE = new StringFlag("farewell", RegionGroup.ALL);
@@ -94,7 +95,8 @@ public final class DefaultFlag {
         MOB_DAMAGE, MOB_SPAWNING, DENY_SPAWN, INVINCIBILITY, EXP_DROPS,
         CREEPER_EXPLOSION, ENDERDRAGON_BLOCK_DAMAGE, GHAST_FIREBALL, ENDER_BUILD,
         GREET_MESSAGE, FAREWELL_MESSAGE, NOTIFY_ENTER, NOTIFY_LEAVE,
-        EXIT, ENTRY, LIGHTNING, ENTITY_PAINTING_DESTROY, ITEM_DROP,
+        EXIT, ENTRY, LIGHTNING, ENTITY_PAINTING_DESTROY,
+        ENTITY_ITEM_FRAME_DESTROY, ITEM_DROP,
         HEAL_AMOUNT, HEAL_DELAY, MIN_HEAL, MAX_HEAL,
         FEED_DELAY, FEED_AMOUNT, MIN_FOOD, MAX_FOOD,
         SNOW_FALL, SNOW_MELT, ICE_FORM, ICE_MELT, GAME_MODE,


### PR DESCRIPTION
- compile against the craftbukkit 0.2 dev builds.
- use the new Hanging events instead of Painting events, if available.
- add a new world option: "mobs.block-item-frame-destroy".
- add a new region flag: "entity-item-frame-destroy".
