### PR TITLE
Add Mycelium-spread flags

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -143,6 +143,7 @@ public class WorldConfiguration {
     public boolean disableIceFormation;
     public boolean disableLeafDecay;
     public boolean disableGrassGrowth;
+    public boolean disableMyceliumSpread;
     public boolean disableEndermanGriefing;
     public boolean regionInvinciblityRemovesMobs;
     public boolean disableDeathMessages;
@@ -359,6 +360,7 @@ public class WorldConfiguration {
         disableIceFormation = getBoolean("dynamics.disable-ice-formation", false);
         disableLeafDecay = getBoolean("dynamics.disable-leaf-decay", false);
         disableGrassGrowth = getBoolean("dynamics.disable-grass-growth", false);
+        disableMyceliumSpread = getBoolean("dynamics.disable-mycelium-spread", false);
 
         useRegions = getBoolean("regions.enable", true);
         regionInvinciblityRemovesMobs = getBoolean("regions.invincibility-removes-mobs", false);

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardBlockListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardBlockListener.java
@@ -726,6 +726,18 @@ public class WorldGuardBlockListener implements Listener {
                 return;
             }
         }
+        
+        if (fromType == BlockID.MYCELIUM) {
+        	    if (wcfg.disableMyceliumSpread) {
+        	    	    event.setCancelled(true);
+        	    	    return;
+        	    }
+        	    if(wcfg.useRegions && !plugin.getGlobalRegionManager().allows(
+        	    		    DefaultFlag.MYCELIUM_SPREAD, event.getBlock().getLocation())) {
+        	    	    event.setCancelled(true);
+        	    	    return;
+        	    }
+        }
     }
 
     /*

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -57,6 +57,7 @@ public final class DefaultFlag {
     public static final StateFlag MUSHROOMS = new StateFlag("mushroom-growth", true);
     public static final StateFlag LEAF_DECAY = new StateFlag("leaf-decay", true);
     public static final StateFlag GRASS_SPREAD = new StateFlag("grass-growth", true);
+    public static final StateFlag MYCELIUM_SPREAD = new StateFlag("mycelium-spread", true);
     public static final StateFlag ENDER_BUILD = new StateFlag("enderman-grief", true);
     public static final StateFlag INVINCIBILITY = new StateFlag("invincible", false, RegionGroup.ALL);
     public static final StateFlag EXP_DROPS = new StateFlag("exp-drops", true, RegionGroup.ALL);
@@ -100,8 +101,8 @@ public final class DefaultFlag {
         HEAL_AMOUNT, HEAL_DELAY, MIN_HEAL, MAX_HEAL,
         FEED_DELAY, FEED_AMOUNT, MIN_FOOD, MAX_FOOD,
         SNOW_FALL, SNOW_MELT, ICE_FORM, ICE_MELT, GAME_MODE,
-        MUSHROOMS, LEAF_DECAY, GRASS_SPREAD, SEND_CHAT, RECEIVE_CHAT,
-        FIRE_SPREAD, LAVA_FIRE, LAVA_FLOW, WATER_FLOW,
+        MUSHROOMS, LEAF_DECAY, GRASS_SPREAD, MYCELIUM_SPREAD, SEND_CHAT,
+        RECEIVE_CHAT, FIRE_SPREAD, LAVA_FIRE, LAVA_FLOW, WATER_FLOW,
         TELE_LOC, SPAWN_LOC, POTION_SPLASH,
         BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE,
     };


### PR DESCRIPTION
A very small change to add in WorldGuard mycelium-spread flags and a dynamic.disable-mycelium-spread boolean.
