### PR TITLE
Split Construct flag into Construct/Destroy for Place/Break events

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardBlockListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardBlockListener.java
@@ -140,7 +140,7 @@ public class WorldGuardBlockListener implements Listener {
         }
 
         if (!plugin.getGlobalRegionManager().canBuild(player, event.getBlock())
-         || !plugin.getGlobalRegionManager().canConstruct(player, event.getBlock())) {
+         || !plugin.getGlobalRegionManager().canDestroy(player, event.getBlock())) {
             player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
             event.setCancelled(true);
             return;

--- a/src/main/java/com/sk89q/worldguard/protection/ApplicableRegionSet.java
+++ b/src/main/java/com/sk89q/worldguard/protection/ApplicableRegionSet.java
@@ -66,7 +66,12 @@ public class ApplicableRegionSet implements Iterable<ProtectedRegion> {
         final RegionGroup flag = getFlag(DefaultFlag.CONSTRUCT, player);
         return RegionGroupFlag.isMember(this, flag, player);
     }
-
+    
+    public boolean canDestroy(LocalPlayer player) {
+        final RegionGroup flag = getFlag(DefaultFlag.DESTROY, player);
+        return RegionGroupFlag.isMember(this, flag, player);
+    }
+    
     /**
      * Checks if a player can use buttons and such in an area.
      * 

--- a/src/main/java/com/sk89q/worldguard/protection/GlobalRegionManager.java
+++ b/src/main/java/com/sk89q/worldguard/protection/GlobalRegionManager.java
@@ -337,6 +337,35 @@ public class GlobalRegionManager {
         return true;
     }
 
+    public boolean canDestroy(Player player, Block block) {
+        return canDestroy(player, block.getLocation());
+    }
+    
+    public boolean canDestroy(Player player, Location loc) {
+        World world = loc.getWorld();
+        WorldConfiguration worldConfig = config.get(world);
+
+        if (!worldConfig.useRegions) {
+            return true;
+        }
+
+        LocalPlayer localPlayer = plugin.wrapPlayer(player);
+
+        if (!hasBypass(player, world)) {
+            RegionManager mgr = get(world);
+
+            final ApplicableRegionSet applicableRegions = mgr.getApplicableRegions(BukkitUtil.toVector(loc));
+            if (!applicableRegions.canBuild(localPlayer)) {
+                return false;
+            }
+            if (!applicableRegions.canDestroy(localPlayer)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+    
     /**
      * Checks to see whether a flag is allowed.
      *

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -31,6 +31,7 @@ public final class DefaultFlag {
     public static final StateFlag PASSTHROUGH = new StateFlag("passthrough", false, RegionGroup.ALL);
     public static final StateFlag BUILD = new StateFlag("build", true, RegionGroup.NON_MEMBERS);
     public static final RegionGroupFlag CONSTRUCT = new RegionGroupFlag("construct", RegionGroup.MEMBERS);
+    public static final RegionGroupFlag DESTROY = new RegionGroupFlag("destroy", RegionGroup.MEMBERS);
     public static final StateFlag PVP = new StateFlag("pvp", true, RegionGroup.ALL);
     public static final StateFlag MOB_DAMAGE = new StateFlag("mob-damage", true, RegionGroup.ALL);
     public static final StateFlag MOB_SPAWNING = new StateFlag("mob-spawning", true, RegionGroup.ALL);


### PR DESCRIPTION
Update src/main/java/com/sk89q/worldguard/bukkit/WorldGuardBlockListener.java
change canConstruct(player,block) call to canDestroy(player,block)

Update src/main/java/com/sk89q/worldguard/protection/GlobalRegionManager.java
add methods mirrored from construct methods
public boolean canDestroy(Player player, Block block)
public boolean canDestroy(Player player, Location loc)

Update src/main/java/com/sk89q/worldguard/protection/ApplicableRegionSet.java
add canDestroy method

Update src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
add destroy flag
