### PR TITLE
Adds a MAX_PLAYERS flag so you can limit the number of players in a region.

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
@@ -121,7 +121,40 @@ public class WorldGuardPlayerListener implements Listener {
                         event.setTo(newLoc);
                         return;
                     }
-
+                    
+                    // check if region is full
+                    Integer maxPlayers = set.getFlag(DefaultFlag.MAX_PLAYERS);
+                    if(maxPlayers != null) //don't even check if maxPlayers isn't set
+                    {
+                        for(ProtectedRegion region : set)
+                        {
+                            int occupantCount = 0;
+                            for(Player daPlayer : world.getPlayers())
+                            {
+                                // Make sure you're not checking the same player,
+                                // that you're not counting the region owner,
+                                // and that the player doesn't have bypass (they don't count either)
+                                if(!daPlayer.equals(player) && !region.isOwner(daPlayer.getName()) && !plugin.getGlobalRegionManager().hasBypass(daPlayer, world))
+                                    if(region.contains(daPlayer.getLocation().getBlockX(),daPlayer.getLocation().getBlockY(),daPlayer.getLocation().getBlockZ()))
+                                        occupantCount++;                      
+                            }
+                            if (occupantCount >= maxPlayers && !hasBypass) { // setting max_players to 0 does same thing as setting to 1
+                                String message = set.getFlag(DefaultFlag.MAX_PLAYERS_MESSAGE);
+                                if(message!=null)
+                                    player.sendMessage(ChatColor.DARK_RED + message);
+                                else
+                                    player.sendMessage(ChatColor.DARK_RED + "Region is full.");
+        
+                                Location newLoc = event.getFrom();
+                                newLoc.setX(newLoc.getBlockX() + 0.5);
+                                newLoc.setY(newLoc.getBlockY());
+                                newLoc.setZ(newLoc.getBlockZ() + 0.5);
+                                event.setTo(newLoc);
+                                return;
+                            }
+                        }
+                    }
+                    
                     // Have to set this state
                     if (state.lastExitAllowed == null) {
                         state.lastExitAllowed = mgr.getApplicableRegions(toVector(event.getFrom()))

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -71,6 +71,7 @@ public final class DefaultFlag {
     public static final StateFlag POTION_SPLASH = new StateFlag("potion-splash", true);
     public static final StringFlag GREET_MESSAGE = new StringFlag("greeting", RegionGroup.ALL);
     public static final StringFlag FAREWELL_MESSAGE = new StringFlag("farewell", RegionGroup.ALL);
+    public static final StringFlag MAX_PLAYERS_MESSAGE = new StringFlag("max-players-reject-message", RegionGroup.ALL);
     public static final BooleanFlag NOTIFY_ENTER = new BooleanFlag("notify-enter", RegionGroup.ALL);
     public static final BooleanFlag NOTIFY_LEAVE = new BooleanFlag("notify-leave", RegionGroup.ALL);
     public static final SetFlag<EntityType> DENY_SPAWN = new SetFlag<EntityType>("deny-spawn", RegionGroup.ALL, new EntityTypeFlag(null));
@@ -83,6 +84,7 @@ public final class DefaultFlag {
     public static final IntegerFlag FEED_AMOUNT = new IntegerFlag("feed-amount", RegionGroup.ALL);
     public static final IntegerFlag MIN_FOOD = new IntegerFlag("feed-min-hunger", RegionGroup.ALL);
     public static final IntegerFlag MAX_FOOD = new IntegerFlag("feed-max-hunger", RegionGroup.ALL);
+    public static final IntegerFlag MAX_PLAYERS = new IntegerFlag("max-players-allowed", RegionGroup.ALL); //added by TopHatHacker
     public static final LocationFlag TELE_LOC = new LocationFlag("teleport", RegionGroup.MEMBERS);
     public static final LocationFlag SPAWN_LOC = new LocationFlag("spawn", RegionGroup.MEMBERS);
     public static final BooleanFlag BUYABLE = new BooleanFlag("buyable");
@@ -97,7 +99,7 @@ public final class DefaultFlag {
         CREEPER_EXPLOSION, ENDERDRAGON_BLOCK_DAMAGE, GHAST_FIREBALL, ENDER_BUILD,
         GREET_MESSAGE, FAREWELL_MESSAGE, NOTIFY_ENTER, NOTIFY_LEAVE,
         EXIT, ENTRY, LIGHTNING, ENTITY_PAINTING_DESTROY,
-        ENTITY_ITEM_FRAME_DESTROY, ITEM_DROP,
+        ENTITY_ITEM_FRAME_DESTROY, ITEM_DROP, MAX_PLAYERS, MAX_PLAYERS_MESSAGE,
         HEAL_AMOUNT, HEAL_DELAY, MIN_HEAL, MAX_HEAL,
         FEED_DELAY, FEED_AMOUNT, MIN_FOOD, MAX_FOOD,
         SNOW_FALL, SNOW_MELT, ICE_FORM, ICE_MELT, GAME_MODE,


### PR DESCRIPTION
Adds MAX_PLAYERS and MAX_PLAYERS_MESSAGE flags so you can limit the number of players in a region. It rejects players in the same fashion as deny entry. I'm using this to make sure only one player per level of a maze.

Signed-off-by: Ryan Hatfield tophathacker@gmail.com
