### PR TITLE
Fix half-step block protection

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlayerListener.java
@@ -642,6 +642,19 @@ public class WorldGuardPlayerListener implements Listener {
         ConfigurationManager cfg = plugin.getGlobalStateManager();
         WorldConfiguration wcfg = cfg.get(world);
 
+        // work around to fix a CraftBukkit bug
+        if (item.getTypeId() == BlockID.STEP) {
+            if (wcfg.useRegions) {
+                final Location location = block.getLocation();
+                if (!plugin.getGlobalRegionManager().canBuild(player, location)
+                 || !plugin.getGlobalRegionManager().canConstruct(player, location)) {
+                    player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+        }
+        
         // Infinite stack removal
         if ((type == BlockID.CHEST
                 || type == BlockID.JUKEBOX


### PR DESCRIPTION
A simple work around to fix a craftbukkit bug that allows people to place step blocks on protected areas.

https://bukkit.atlassian.net/browse/BUKKIT-2469
https://bukkit.atlassian.net/browse/BUKKIT-3426
