### PR TITLE
Add some command aliases to RegionMemberCommands

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionMemberCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/RegionMemberCommands.java
@@ -45,7 +45,7 @@ public class RegionMemberCommands {
         this.plugin = plugin;
     }
 
-    @Command(aliases = {"addmember", "addmember"},
+    @Command(aliases = {"addmember", "addmember", "addmem", "am"},
             usage = "<id> <members...>",
             flags = "w:",
             desc = "Add a member to a region",
@@ -96,7 +96,7 @@ public class RegionMemberCommands {
         }
     }
 
-    @Command(aliases = {"addowner", "addowner"},
+    @Command(aliases = {"addowner", "addowner", "ao"},
             usage = "<id> <owners...>",
             flags = "w:",
             desc = "Add an owner to a region",
@@ -160,7 +160,7 @@ public class RegionMemberCommands {
         }
     }
 
-    @Command(aliases = {"removemember", "remmember", "removemem", "remmem"},
+    @Command(aliases = {"removemember", "remmember", "removemem", "remmem", "rm"},
             usage = "<id> <owners...>",
             flags = "w:",
             desc = "Remove an owner to a region",
@@ -211,7 +211,7 @@ public class RegionMemberCommands {
         }
     }
 
-    @Command(aliases = {"removeowner", "remowner"},
+    @Command(aliases = {"removeowner", "remowner", "ro"},
             usage = "<id> <owners...>",
             flags = "w:",
             desc = "Remove an owner to a region",


### PR DESCRIPTION
This adds some shorter aliases so people don't have to type "addmember" but they can just type "am", "ao", "rm" or "ro".
