### PR TITLE
Fix Explosion Check Order

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -568,13 +568,12 @@ public class WorldGuardEntityListener implements Listener {
         }
 
         if (ent instanceof Creeper) {
-            if (wcfg.blockCreeperBlockDamage) {
-                event.blockList().clear();
-                return;
-            }
-
             if (wcfg.blockCreeperExplosions) {
                 event.setCancelled(true);
+                return;
+            }
+            if (wcfg.blockCreeperBlockDamage) {
+                event.blockList().clear();
                 return;
             }
 
@@ -608,13 +607,12 @@ public class WorldGuardEntityListener implements Listener {
                 }
             }
         } else if (ent instanceof TNTPrimed || (ent != null && ent.getType() == tntMinecartType)) {
-            if (wcfg.blockTNTBlockDamage) {
-                event.blockList().clear();
-                return;
-            }
-
             if (wcfg.blockTNTExplosions) {
                 event.setCancelled(true);
+                return;
+            }
+            if (wcfg.blockTNTBlockDamage) {
+                event.blockList().clear();
                 return;
             }
 
@@ -631,23 +629,21 @@ public class WorldGuardEntityListener implements Listener {
             }
         } else if (ent instanceof Fireball) {
             if (ent instanceof WitherSkull) {
-                if (wcfg.blockWitherSkullBlockDamage) {
-                    event.blockList().clear();
-                    return;
-                }
-
                 if (wcfg.blockWitherSkullExplosions) {
                     event.setCancelled(true);
                     return;
                 }
-            } else {
-                if (wcfg.blockFireballBlockDamage) {
+                if (wcfg.blockWitherSkullBlockDamage) {
                     event.blockList().clear();
                     return;
                 }
-
+            } else {
                 if (wcfg.blockFireballExplosions) {
                     event.setCancelled(true);
+                    return;
+                }
+                if (wcfg.blockFireballBlockDamage) {
+                    event.blockList().clear();
                     return;
                 }
             }
@@ -664,13 +660,12 @@ public class WorldGuardEntityListener implements Listener {
                 }
             }
         } else if (ent instanceof Wither) {
-            if (wcfg.blockWitherBlockDamage) {
-                event.blockList().clear();
-                return;
-            }
-
             if (wcfg.blockWitherExplosions) {
                 event.setCancelled(true);
+                return;
+            }
+            if (wcfg.blockWitherBlockDamage) {
+                event.blockList().clear();
                 return;
             }
         } else {


### PR DESCRIPTION
Example of the problem

There are two options
- BlockCreeperExplosions
- BlockCreeperExplosionBlockDamage

If both are set, only the block damage is handled in the EntityExplodeEvent cases.
