### PR TITLE
Fixed volume() function for PolygonalRegion

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -158,41 +158,17 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
 
     @Override
     public int volume() {
-        int volume = 0;
-        // TODO: Fix this
-        /*int numPoints = points.size();
-        if (numPoints < 3) {
-            return 0;
-        }
-
-        double area = 0;
-        int xa, z1, z2;
-
-        for (int i = 0; i < numPoints; i++) {
-            xa = points.get(i).getBlockX();
-            //za = points.get(i).getBlockZ();
-
-            if (points.get(i + 1) == null) {
-                z1 = points.get(0).getBlockZ();
-            } else {
-                z1 = points.get(i + 1).getBlockZ();
+        int surface = 0;
+        for (int x = min.getBlockX(); x <= max.getBlockX(); x++) {
+            for (int z = min.getBlockZ(); z <= max.getBlockZ(); z++) {
+                if (this.contains(x, minY, z)) {
+                    surface++;
+                }
             }
-            if (points.get(i - 1) == null) {
-                z2 = points.get(numPoints - 1).getBlockZ();
-            } else {
-                z2 = points.get(i - 1).getBlockZ();
-            }
-
-            area = area + (xa * (z1 - z2));
         }
+        
+        int height = maxY - minY + 1;
 
-        xa = points.get(0).getBlockX();
-        //za = points.get(0).getBlockZ();
-
-        area = area + (xa * (points.get(1).getBlockZ() - points.get(numPoints - 1).getBlockZ()));
-
-        volume = (Math.abs(maxY - minY) + 1) * (int) Math.ceil((Math.abs(area) / 2));*/
-
-        return volume;
+        return surface * height;
     }
 }


### PR DESCRIPTION
This fix is making use of the contains() method, as a normal
poly-volume-calculation would not return the exact amount of blocks
protected.

I already brought that up <a href="http://forum.sk89q.com/threads/polygon-region-volume-always-0.1416/">over a year ago on the forums</a> and later <a href="http://redmine.sk89q.com/issues/1520#change-3955">as a ticket</a>. Now that I've learned to work a very little with Git I thought I'll send a pull-request.
