### PR TITLE
Fixes heal flag bugs when player.maxHealth > 20

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/FlagStateManager.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/FlagStateManager.java
@@ -119,7 +119,7 @@ public class FlagStateManager implements Runnable {
             return;
         }
         if (minHealth == null) minHealth = 0;
-        if (maxHealth == null) maxHealth = 20;
+        if (maxHealth == null) maxHealth = player.getMaxHealth();
 
         // Apply a cap to prevent possible exceptions
         minHealth = Math.min(player.getMaxHealth(), minHealth);


### PR DESCRIPTION
With the new Bukkit Changes the Player Health can be above 20, this fixes the magic number by using the now built in Bukkit functionality.

Examples of this bug were Health jumping to 1/20 hearts when having a heal-amount: -1
