### PR TITLE
Item Blacklist for /stack

### DIFF
--- a/src/main/java/com/sk89q/worldguard/blacklist/Blacklist.java
+++ b/src/main/java/com/sk89q/worldguard/blacklist/Blacklist.java
@@ -223,6 +223,8 @@ public abstract class Blacklist {
                             entry.setDropActions(parts[1].split(","));
                         } else if (parts[0].equalsIgnoreCase("on-acquire")) {
                             entry.setAcquireActions(parts[1].split(","));
+                        } else if (parts[0].equalsIgnoreCase("on-stack")) {
+                        	entry.setStackActions(parts[1].split(","));
                         } else if (parts[0].equalsIgnoreCase("message")) {
                             entry.setMessage(parts[1].trim());
                         } else if (parts[0].equalsIgnoreCase("comment")) {

--- a/src/main/java/com/sk89q/worldguard/blacklist/BlacklistEntry.java
+++ b/src/main/java/com/sk89q/worldguard/blacklist/BlacklistEntry.java
@@ -34,6 +34,7 @@ import com.sk89q.worldguard.blacklist.events.BlockPlaceBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.DestroyWithBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemAcquireBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemDropBlacklistEvent;
+import com.sk89q.worldguard.blacklist.events.ItemStackBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemUseBlacklistEvent;
 
 /**
@@ -63,6 +64,7 @@ public class BlacklistEntry {
     private String[] useActions;
     private String[] dropActions;
     private String[] acquireActions;
+    private String[] stackActions;
 
     private String message;
     private String comment;
@@ -207,6 +209,20 @@ public class BlacklistEntry {
     public void setAcquireActions(String[] actions) {
         this.acquireActions = actions;
     }
+    
+    /**
+     * @return The actions that will occur when stacking
+     */
+    public String[] getStackActions() {
+    	return stackActions;
+    }
+    
+    /**
+     * @param actions The actions to occur when stacking
+     */
+    public void setStackActions(String[] actions) {
+    	this.stackActions = actions;
+    }
 
     /**
      * @return the message
@@ -290,6 +306,9 @@ public class BlacklistEntry {
         } else if (event instanceof ItemUseBlacklistEvent) {
             return useActions;
 
+        } else if (event instanceof ItemStackBlacklistEvent) {
+        	return stackActions;
+        	
         } else {
             return null;
         }

--- a/src/main/java/com/sk89q/worldguard/blacklist/events/ItemStackBlacklistEvent.java
+++ b/src/main/java/com/sk89q/worldguard/blacklist/events/ItemStackBlacklistEvent.java
@@ -1,0 +1,36 @@
+// $Id$
+/*
+ * WorldGuard
+ * Copyright (C) 2010 sk89q <http://www.sk89q.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.sk89q.worldguard.blacklist.events;
+
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldguard.LocalPlayer;
+
+public class ItemStackBlacklistEvent extends ItemBlacklistEvent{
+	
+    public ItemStackBlacklistEvent(LocalPlayer player, Vector pos, int type) {
+		super(player, pos, type);
+	}
+    
+    @Override
+    public String getDescription() {
+        return "stack";
+    }
+
+}

--- a/src/main/java/com/sk89q/worldguard/blacklist/loggers/ConsoleLoggerHandler.java
+++ b/src/main/java/com/sk89q/worldguard/blacklist/loggers/ConsoleLoggerHandler.java
@@ -30,6 +30,7 @@ import com.sk89q.worldguard.blacklist.events.BlockPlaceBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.DestroyWithBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemAcquireBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemDropBlacklistEvent;
+import com.sk89q.worldguard.blacklist.events.ItemStackBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemUseBlacklistEvent;
 
 /**
@@ -97,6 +98,13 @@ public class ConsoleLoggerHandler implements BlacklistLoggerHandler {
             logger.log(Level.INFO, "[" + worldName + "] " + event.getPlayer().getName()
                     + " tried to use " + getFriendlyItemName(evt.getType())
                     + (comment != null ? " (" + comment + ")" : ""));
+         
+        // Stack
+        } else if (event instanceof ItemStackBlacklistEvent) {
+        	ItemStackBlacklistEvent evt = (ItemStackBlacklistEvent)event;
+        	logger.log(Level.INFO, "[" + worldName + "]" + event.getPlayer().getName()
+        			+ " tried to stack " + getFriendlyItemName(evt.getType())
+        			+ (comment != null ? " (" + comment + ")" : ""));
 
         // Unknown
         } else {

--- a/src/main/java/com/sk89q/worldguard/blacklist/loggers/DatabaseLoggerHandler.java
+++ b/src/main/java/com/sk89q/worldguard/blacklist/loggers/DatabaseLoggerHandler.java
@@ -35,6 +35,7 @@ import com.sk89q.worldguard.blacklist.events.BlockInteractBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.DestroyWithBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemAcquireBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemDropBlacklistEvent;
+import com.sk89q.worldguard.blacklist.events.ItemStackBlacklistEvent;
 import com.sk89q.worldguard.blacklist.events.ItemUseBlacklistEvent;
 
 /**
@@ -183,6 +184,11 @@ public class DatabaseLoggerHandler implements BlacklistLoggerHandler {
             logEvent("USE", evt.getPlayer(), evt.getPlayer().getPosition(),
                     evt.getType(), comment);
 
+        // Stack
+        } else if (event instanceof ItemStackBlacklistEvent) {
+        	ItemStackBlacklistEvent evt = (ItemStackBlacklistEvent)event;
+        	logEvent("STACK", evt.getPlayer(), evt.getPlayer().getPosition(),
+        			evt.getType(), comment);
         // Unknown
         } else {
             logEvent("UNKNOWN", event.getPlayer(), event.getPlayer().getPosition(),

--- a/src/main/resources/blacklist.txt
+++ b/src/main/resources/blacklist.txt
@@ -19,6 +19,7 @@
 # - on-interact (when a block in used (doors, chests, etc.))
 # - on-drop (an item is being dropped from the player's inventory)
 # - on-acquire (an item enters a player's inventory via some method)
+# - on-stack (when an item is attempted to stack via /stack)
 #
 # Actions (for events):
 # - deny (deny completely, used blacklist mode)


### PR DESCRIPTION
Added an Item Blacklist for the /stack command
/stack will basically not stack anything blacklisted.
Created so players on servers (such as donators) have access to the usefulness of /stack, without ruining certain aspects of the game.
One example is potions on PvP servers. With stacked potions, players would have a significant advantage.
