### PR TITLE
Alert a user whenever they take advantage of their bypass permission

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardBlockListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardBlockListener.java
@@ -147,8 +147,7 @@ public class WorldGuardBlockListener implements Listener {
             }
         }
 
-        if (!plugin.getGlobalRegionManager().canBuild(player, event.getBlock())
-         || !plugin.getGlobalRegionManager().canConstruct(player, event.getBlock())) {
+        if (!plugin.getGlobalRegionManager().canConstruct(player, event.getBlock())) {
             player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
             event.setCancelled(true);
             return;
@@ -338,7 +337,7 @@ public class WorldGuardBlockListener implements Listener {
             RegionManager mgr = plugin.getGlobalRegionManager().get(world);
             ApplicableRegionSet set = mgr.getApplicableRegions(pt);
 
-            if (player != null && !plugin.getGlobalRegionManager().hasBypass(player, world)) {
+            if (player != null) {
                 LocalPlayer localPlayer = plugin.wrapPlayer(player);
 
                 // this is preliminarily handled in the player listener under handleBlockRightClick
@@ -346,7 +345,8 @@ public class WorldGuardBlockListener implements Listener {
                 if (cause == IgniteCause.FLINT_AND_STEEL || cause == IgniteCause.FIREBALL) {
                     if (!set.allows(DefaultFlag.LIGHTER)
                             && !set.canBuild(localPlayer)
-                            && !plugin.hasPermission(player, "worldguard.override.lighter")) {
+                            && !plugin.hasPermission(player, "worldguard.override.lighter")
+                            && !plugin.getGlobalRegionManager().hasBypass(player, world, set)) {
                         event.setCancelled(true);
                         return;
                     }
@@ -505,8 +505,7 @@ public class WorldGuardBlockListener implements Listener {
 
         if (wcfg.useRegions) {
             final Location location = blockPlaced.getLocation();
-            if (!plugin.getGlobalRegionManager().canBuild(player, location)
-             || !plugin.getGlobalRegionManager().canConstruct(player, location)) {
+            if (!plugin.getGlobalRegionManager().canConstruct(player, location)) {
                 player.sendMessage(ChatColor.DARK_RED + "You don't have permission for this area.");
                 event.setCancelled(true);
                 return;

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardVehicleListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardVehicleListener.java
@@ -62,9 +62,9 @@ public class WorldGuardVehicleListener implements Listener {
             ApplicableRegionSet set = mgr.getApplicableRegions(pt);
             LocalPlayer localPlayer = plugin.wrapPlayer(player);
 
-            if (!plugin.getGlobalRegionManager().hasBypass(player, world)
-                    && !set.canBuild(localPlayer)
-                    && !set.allows(DefaultFlag.DESTROY_VEHICLE, localPlayer)) {
+            if (!set.canBuild(localPlayer)
+                && !set.allows(DefaultFlag.DESTROY_VEHICLE, localPlayer)
+                && !plugin.getGlobalRegionManager().hasBypass(player, world, set)) {
                 player.sendMessage(ChatColor.DARK_RED + "You don't have permission to destroy vehicles here.");
                 event.setCancelled(true);
                 return;


### PR DESCRIPTION
Alert a user whenever they're allowed to do an action because of their worldguard.region.bypass.<world> permission.
Allows staff to realize when they may be unknowingly intruding into a protected region and to avoid awkward situations.

This pull request is sort of proof-of-concept quality admittedly.
I added some overload forms of the hasBypass method on GlobalRegionManager so an ApplicableRegionSet could be passed too, and an optional silent flag which causes no warning to be shown. The hasBypass method does the alert itself, and names the first region in the ApplicableRegionSet if there is one given.

The hasBypass method used to be called before any permissions checks were done, so I re-ordered all of the calls to it to be after the permissions checks so that the alert would only be shown only if the other permissions checks failed.
Since hasBypass is a public method and other plugins might have used it the same way, I left the old two-parameter forms as always silent.

I think the bypassWarning and bypassWarningString methods I added ought not to be inside GlobalRegionManager, but I wasn't yet sure where to put them. This behavior probably should be optional via a config setting. Some single actions in regions with certain protections can cause multiple messages at once (ie: opening a chest in a region where chest-access and use are both denied). Doing a lot of actions in a region can cause bypass warnings to quickly fill the screen, so I think a good solution to both of these problems would be to not display the warning if one had already been displayed to that player within the last 5 seconds or so.
