### PR TITLE
Protect lily pads against boats (Adds WORLDGUARD-2601)

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -91,6 +91,7 @@ public class WorldConfiguration {
     public boolean ropeLadders;
     public boolean allowPortalAnywhere;
     public Set<Integer> preventWaterDamage;
+    public boolean protectLilyPadsAgainstBoats;
     public boolean blockLighter;
     public boolean disableFireSpread;
     public Set<Integer> disableFireSpreadBlocks;
@@ -337,6 +338,7 @@ public class WorldConfiguration {
         ropeLadders = getBoolean("physics.vine-like-rope-ladders", false);
         allowPortalAnywhere = getBoolean("physics.allow-portal-anywhere", false);
         preventWaterDamage = new HashSet<Integer>(getIntList("physics.disable-water-damage-blocks", null));
+        protectLilyPadsAgainstBoats = getBoolean("physics.protect-lily-pads-against-boats", false);
 
         blockTNTExplosions = getBoolean("ignition.block-tnt", false);
         blockTNTBlockDamage = getBoolean("ignition.block-tnt-block-damage", false);

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -26,6 +26,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.EnderPearl;
@@ -888,6 +889,20 @@ public class WorldGuardEntityListener implements Listener {
             if (wcfg.blockZombieDoorDestruction) {
                 event.setCancelled(true);
                 return;
+            }
+        } else if (ent instanceof Boat) {
+            if (wcfg.protectLilyPadsAgainstBoats) {
+                Boat boat = (Boat) ent;
+                Entity passenger = boat.getPassenger();
+                if (!wcfg.useRegions || !(passenger instanceof Player)) {
+                    event.setCancelled(true);
+                    return;
+                }
+                Player player = (Player) passenger;
+                if (!plugin.getGlobalRegionManager().canBuild(player, block.getLocation())) {
+                    event.setCancelled(true);
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
This change allows lily pads to be protected against boats. This is important to prevent griefing.

When regions are switched off, lily pads are protected against all boats. When regions are switched on, anyone who has build permissions is able to destroy the lily pad with a boat.

Adds [WORLDGUARD-2601](http://youtrack.sk89q.com/issue/WORLDGUARD-2601)
