### PR TITLE
PotionSplashEvent fix for empty affected entities list

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -928,6 +928,7 @@ public class WorldGuardEntityListener implements Listener {
         GlobalRegionManager regionMan = plugin.getGlobalRegionManager();
 
         if (event.getAffectedEntities().isEmpty()) {
+            event.setCancelled(!regionMan.allows(DefaultFlag.POTION_SPLASH, potion.getLocation()));
             return;
         }
         


### PR DESCRIPTION
WorldGuard cancells PotionSplashEvent if affected entities is empty. It's problem, while developing grenades etc.
