### PR TITLE
PotionSplashEvent fixes

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -927,7 +927,15 @@ public class WorldGuardEntityListener implements Listener {
 
         GlobalRegionManager regionMan = plugin.getGlobalRegionManager();
 
+        if (event.getAffectedEntities().isEmpty()) {
+            if (!regionMan.allows(DefaultFlag.POTION_SPLASH, potion.getLocation())) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+        
         int blockedEntities = 0;
+        int size = event.getAffectedEntities().size();
         for (LivingEntity e : event.getAffectedEntities()) {
             if (!regionMan.allows(DefaultFlag.POTION_SPLASH, e.getLocation(),
                     e instanceof Player ? plugin.wrapPlayer((Player) e) : null)) {
@@ -936,7 +944,7 @@ public class WorldGuardEntityListener implements Listener {
             }
         }
 
-        if (blockedEntities == event.getAffectedEntities().size()) {
+        if (blockedEntities == size) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
WorldGuard cancells PotionSplashEvent if potion affect any entity. It's problem, while developing grenades etc.
EDIT:
https://github.com/Bukkit/Bukkit/blob/master/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java#L71
WorldGuard sets intensity to 0 if entity is at region with potion-splash set to deny and bukkit deletes entity from affected entities list.
