### PR TITLE
Add bow shooting and general projectile launching flags

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -82,6 +82,8 @@ public class WorldConfiguration {
     public boolean simulateSponge;
     public int spongeRadius;
     public boolean disableExpDrops;
+    public boolean disableProjectileLaunch;
+    public boolean blockBowShoot;
     public Set<PotionEffectType> blockPotions;
     public boolean blockPotionsAlways;
     public boolean pumpkinScuba;
@@ -312,6 +314,8 @@ public class WorldConfiguration {
         removeInfiniteStacks = getBoolean("protection.remove-infinite-stacks", false);
         disableExpDrops = getBoolean("protection.disable-xp-orb-drops", false);
         disableObsidianGenerators = getBoolean("protection.disable-obsidian-generators", false);
+        disableProjectileLaunch = getBoolean("protection.disable-launching-projectiles", false);
+        blockBowShoot = getBoolean("protection.block-bow-shooting", false);
 
         blockPotions = new HashSet<PotionEffectType>();
         for (String potionName : getStringList("gameplay.block-potions", null)) {

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -73,6 +73,8 @@ public final class DefaultFlag {
     public static final StateFlag ENTITY_PAINTING_DESTROY = new StateFlag("entity-painting-destroy", true);
     public static final StateFlag ENTITY_ITEM_FRAME_DESTROY = new StateFlag("entity-item-frame-destroy", true);
     public static final StateFlag POTION_SPLASH = new StateFlag("potion-splash", true);
+    public static final StateFlag PROJECTILE_LAUNCH = new StateFlag("projectile-launch", true);
+    public static final StateFlag BOW_SHOOT = new StateFlag("bow-shoot", true);
     public static final StringFlag GREET_MESSAGE = new StringFlag("greeting", RegionGroup.ALL);
     public static final StringFlag FAREWELL_MESSAGE = new StringFlag("farewell", RegionGroup.ALL);
     public static final BooleanFlag NOTIFY_ENTER = new BooleanFlag("notify-enter", RegionGroup.ALL);
@@ -110,7 +112,7 @@ public final class DefaultFlag {
         SNOW_FALL, SNOW_MELT, ICE_FORM, ICE_MELT, SOIL_DRY, GAME_MODE,
         MUSHROOMS, LEAF_DECAY, GRASS_SPREAD, MYCELIUM_SPREAD, VINE_GROWTH,
         SEND_CHAT, RECEIVE_CHAT, FIRE_SPREAD, LAVA_FIRE, LAVA_FLOW, WATER_FLOW,
-        TELE_LOC, SPAWN_LOC, POTION_SPLASH,
+        TELE_LOC, SPAWN_LOC, POTION_SPLASH, PROJECTILE_LAUNCH, BOW_SHOOT,
         BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ENABLE_SHOP
     };
 


### PR DESCRIPTION
This PR is very similar to #276, but this PR
- actually adds two new region flags, "bow-shoot" and "projectile-launch"
- adds two world configuration nodes to block shooting arrows or to entirely disable launching projectiles.
##### Necessity

As explained in #276, this feature is crucial to prevent a buildup of spammed arrows in certain regions.
It might also be used for creating structures like archery ranges where players are only allowed to shoot in one specific area.
##### Summary of function

What this PR basically does is listen to the events `EntityShootBowEvent` and `ProjectileLaunchEvent`.
If they are disabled by the world configuration or by a region flag, the events are cancelled.

---

<off-topic>
If you want to make collaboration easier, format your code better.
Some files have Windows CRLF line endings, most others have Unix LF line endings, which is annoying to deal with when making a pull request.
There are tons of lines with trailing whitespace, too.
</off-topic>
