### PR TITLE
Fixed ProtectedCuboidRegion::getPoints() returning points in wrong order

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
+++ b/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
@@ -76,6 +76,7 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
         setMinMaxPoints(min, pt);
     }
 
+    @Override
     public List<BlockVector2D> getPoints() {
         List<BlockVector2D> pts = new ArrayList<BlockVector2D>();
         int x1 = min.getBlockX();
@@ -85,8 +86,8 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
 
         pts.add(new BlockVector2D(x1, z1));
         pts.add(new BlockVector2D(x2, z1));
-        pts.add(new BlockVector2D(x1, z2));
         pts.add(new BlockVector2D(x2, z2));
+        pts.add(new BlockVector2D(x1, z2));
 
         return pts;
     }


### PR DESCRIPTION
ProtectedPolygonRegion returns points in an order such that you could play "connect the dots" and end up with the correct polygon. ProtectedCuboidRegion returns them in an order such that playing connect the dots gives you a Z shape. This breaks the intersectsEdges() function in ProtectedRegion when comparing cuboids. This commit causes ProtectedCuboidRegion::getPoints() to return them in an order consistent with ProtectedPolygonRegion, which makes intersectsEdges() work correctly.
