### PR TITLE
Convert region ID to lowercase when saving polygon points to MySQL database.

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/databases/MySQLDatabase.java
+++ b/src/main/java/com/sk89q/worldguard/protection/databases/MySQLDatabase.java
@@ -433,6 +433,12 @@ public class MySQLDatabase extends AbstractProtectionDatabase {
                             poly2dVectorResultSet.getInt("z")
                     ));
                 }
+
+                if (points.size() < 3) {
+                    logger.warning(String.format("Invalid polygonal region '%s': region only has %d point(s). Ignoring.", id, points.size()));
+                    continue;
+                }
+
                 ProtectedRegion region = new ProtectedPolygonalRegion(id, points, minY, maxY);
 
                 region.setPriority(poly2dResultSet.getInt("priority"));
@@ -932,7 +938,7 @@ public class MySQLDatabase extends AbstractProtectionDatabase {
                 ") VALUES (null, ?, " + this.worldDbId + ", ?, ?)"
         );
 
-        String lowerId = region.getId();
+        String lowerId = region.getId().toLowerCase();
         for (BlockVector2D point : region.getPoints()) {
             insertPoly2dPointStatement.setString(1, lowerId);
             insertPoly2dPointStatement.setInt(2, point.getBlockZ());


### PR DESCRIPTION
When saving the points of a polygonal region to a MySQL database, the region ID was not converted to lowercase. If a region ID contained a capital letter, upon reload no points would be found, causing an out-of-bounds exception and essentially leaving WorldGuard unusable.
