### PR TITLE
Deletes region entries from the region_cuboid MySQL table

### DIFF
--- a/src/main/java/com/sk89q/worldguard/protection/databases/MySQLDatabase.java
+++ b/src/main/java/com/sk89q/worldguard/protection/databases/MySQLDatabase.java
@@ -741,7 +741,6 @@ public class MySQLDatabase extends AbstractProtectionDatabase {
                 removeRegion.execute();
                 removeCuboidRegion.execute();
                 
-                removeRegion.close();
                 removeCuboidRegion.close();
             } catch (SQLException ex) {
                 logger.warning("Could not remove region from database " + name + ": " + ex.getMessage());


### PR DESCRIPTION
Before this fix, entries were only deleted from all of the tables but the region_cuboid table, resulting in orphaned table entries.
Fixes WORLDGUARD-2994 and WORLDGUARD-2330
