### PR TITLE
Remove zml-repo from pom.xml as it failed to resolve anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,6 @@
       <url>http://maven.sk89q.com/repo/</url>
     </repository>
     <repository>
-      <id>zml-repo</id>
-      <url>http://files.zachsthings.com/repo</url>
-    </repository>
-    <repository>
       <id>bukkit-repo</id>
       <url>http://repo.bukkit.org/content/groups/public</url>
     </repository>


### PR DESCRIPTION
Remove zml-repo from pom.xml as it failed to resolve anymore, causing Maven builds to have to wait for extended periods of time

The repository at http://files.zachsthings.com/repo fails to resolve anymore, and is causing Maven builds for WorldGuard and anything with WG as an upstream to hang while it attempts to download org.bukkit:bukkit:1.6.2-R0.1-SNAPSHOT

Tested ability to build by clearing out local dependencies and rebuilding, as described here: http://stackoverflow.com/a/2776387/979574
