### PR TITLE
Show more details in error log which world the error belongs to.

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -36,6 +36,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
+import org.yaml.snakeyaml.parser.ParserException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -336,6 +337,9 @@ public class WorldConfiguration {
         } catch (IOException e) {
             log.severe("Error reading configuration for world " + worldName + ": ");
             e.printStackTrace();
+        } catch (ParserException e) {
+            log.severe("Error parsing configuration for world " + worldName + ". ");
+            throw e;
         }
 
         summaryOnStart = getBoolean("summary-on-start", true);


### PR DESCRIPTION
I had big troubles finding the right world belonging to a parse exception that appeared in my log (after a failed ftp upload). 
Usually searching for this kind of error is really simple, but i had round about 50 worlds to check, which droved me crazy. The error message is better than CB ones, but i still had no clue what was the actual issue before seeing the corrupted file.

So this PR adds a hint which file is corrupted to the log.

Here is an example from my log (without PR):

```
[09:47:20] [Server thread/INFO]: [WorldGuard] Enabling WorldGuard v6.0.0-beta-02
[09:47:21] [Server thread/ERROR]: Error occurred while enabling WorldGuard v6.0.0-beta-02 (Is it up to date?)
org.yaml.snakeyaml.parser.ParserException: null; expected '<document start>', but found BlockMappingStart;  in 'reader', line 13, column 2:
     ignition:
     ^
    at org.yaml.snakeyaml.parser.ParserImpl$ParseDocumentStart.produce(ParserImpl.java:225) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:158) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    at org.yaml.snakeyaml.parser.ParserImpl.checkEvent(ParserImpl.java:143) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    at org.yaml.snakeyaml.composer.Composer.getSingleNode(Composer.java:108) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    at org.yaml.snakeyaml.constructor.BaseConstructor.getSingleData(BaseConstructor.java:120) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    at org.yaml.snakeyaml.Yaml.loadFromReader(Yaml.java:481) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    at org.yaml.snakeyaml.Yaml.load(Yaml.java:424) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    at com.sk89q.util.yaml.YAMLProcessor.load(YAMLProcessor.java:111) ~[?:?]
    at com.sk89q.worldguard.bukkit.WorldConfiguration.loadConfiguration(WorldConfiguration.java:335) ~[?:?]
    at com.sk89q.worldguard.bukkit.WorldConfiguration.<init>(WorldConfiguration.java:211) ~[?:?]
    at com.sk89q.worldguard.bukkit.ConfigurationManager.get(ConfigurationManager.java:235) ~[?:?]
    at com.sk89q.worldguard.bukkit.ConfigurationManager.load(ConfigurationManager.java:202) ~[?:?]
    at com.sk89q.worldguard.bukkit.WorldGuardPlugin.onEnable(WorldGuardPlugin.java:200) ~[?:?]
    at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:316) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    [...]
```

With PR:

```
[11:21:55] [Server thread/INFO]: [WorldGuard] Enabling WorldGuard v6.0.0-beta-02
[11:21:55] [Server thread/ERROR]: Error parsing configuration for world Survival_City_Nether.
[11:21:55] [Server thread/ERROR]: Error occurred while enabling WorldGuard v6.0.0-beta-02 (Is it up to date?)
org.yaml.snakeyaml.parser.ParserException: null; expected '<document start>', but found BlockMappingStart;  in 'reader', line 13, column 2:
     ignition:
     ^
    at org.yaml.snakeyaml.parser.ParserImpl$ParseDocumentStart.produce(ParserImpl.java:225) ~[craftbukkit.jar:git-Spigot-1.7.9-R0.2-208-ge0f2e95]
    [...]
```
