### PR TITLE
Make sign interaction be counted as a use

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -806,6 +806,8 @@ public final class Materials {
             case JUNGLE_DOOR: return true;
             case ACACIA_DOOR: return true;
             case DARK_OAK_DOOR: return true;
+            case WALL_SIGN: return true;
+            case SIGN_POST: return true;
             default: return false;
         }
     }


### PR DESCRIPTION
Since the change to the json formatting signs are able to include a clickEvent. ~~Currently you need to allow all Interactions with the interact flag to allow that but it fits right in with the other use flag cases.~~ EDIT: Apparently this is not the case with Vanilla sign events (they bypass all protections) and only a problem with how certain plugins check if signs can be used (via calling the [ProtectionQuery.testBlockInteract()](https://github.com/sk89q/WorldGuard/blob/master/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/ProtectionQuery.java#L88) method which returns false for signs as long as the full interact flag isn't set)

This also fixes the issue of allowing certain CraftBook sign mechanics in protected regions (like elevators).