### PR TITLE
Add SNOWMAN_TRAILS flag

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
@@ -508,6 +508,12 @@ public class WorldGuardBlockListener implements Listener {
                     event.setCancelled(true);
                     return;
                 }
+                if (wcfg.useRegions) {
+                    if (!plugin.getGlobalRegionManager().allows(DefaultFlag.SNOWMAN_TRAILS, event.getBlock().getLocation())) {
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
             }
             return;
         }

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -84,6 +84,7 @@ public final class DefaultFlag {
     public static final StateFlag PISTONS = new StateFlag("pistons", true);
     public static final StateFlag SNOW_FALL = new StateFlag("snow-fall", true);
     public static final StateFlag SNOW_MELT = new StateFlag("snow-melt", true);
+    public static final StateFlag SNOWMAN_TRAILS = new StateFlag("snowman-trails", true);
     public static final StateFlag ICE_FORM = new StateFlag("ice-form", true);
     public static final StateFlag ICE_MELT = new StateFlag("ice-melt", true);
     public static final StateFlag MUSHROOMS = new StateFlag("mushroom-growth", true);
@@ -159,7 +160,7 @@ public final class DefaultFlag {
             MUSHROOMS, LEAF_DECAY, GRASS_SPREAD, MYCELIUM_SPREAD, VINE_GROWTH,
             SEND_CHAT, RECEIVE_CHAT, FIRE_SPREAD, LAVA_FIRE, LAVA_FLOW, WATER_FLOW,
             TELE_LOC, SPAWN_LOC, POTION_SPLASH, TIME_LOCK, WEATHER_LOCK,
-            BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ENABLE_SHOP
+            BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ENABLE_SHOP, SNOWMAN_TRAILS
     };
 
     private DefaultFlag() {


### PR DESCRIPTION
Hi,

I've add a new flag "SNOWMAN_TRAILS" because i want my players can use this function but not in my spawn.
This flag add the function to allow or not the trails left by the snowmen in a region.
I've see in the config that is possible to disabled in a world but it's an issue here, i've test this and it's working.

Fabien