### PR TITLE
[WIP] Allow NPCs to bypass region protections.

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/InteropUtils.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/InteropUtils.java
@@ -70,6 +70,10 @@ public final class InteropUtils {
         UUID uuid = player.getUniqueId();
         String name = player.getName();
 
+        if (player.hasMetadata("NPC")) {
+            return true;
+        }
+
         if (uuid.equals(forgeFakePlayerUuid)) {
             return true;
         }


### PR DESCRIPTION
Plugins such as Citizens create fake Players on the server as NPCs. These NPCs trigger many of the same events that normal players do. Normally this would mean that you can even add the NPC (by UUID) to a region. However, when bypass permissions are checked, some permissions plugins (just LuckPerms? unsure of others) refuse to do permissions lookups on the main thread (since it requires UUID resolution?).
There is a config setting to allow this, but presumably(?) the lookup comes up false anyway (unless the admin actually assigned NPCs permissions).
It might be worth making a config setting for this option (in case NPCs should be restricted?), and double-checking what the actual behavior of LuckPerms is in these cases.