### PR TITLE
Moved SquirrelID relocation to core project.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'worldguard'
 
-include 'worldguard-core', 'worldguard-sponge', 'worldguard-legacy'
+include 'worldguard-core', 'worldguard-legacy'

--- a/worldguard-core/build.gradle
+++ b/worldguard-core/build.gradle
@@ -14,12 +14,16 @@ dependencies {
 sourceSets {
     main {
         java {
-	    srcDir 'src/main/java'
-	}
+            srcDir 'src/main/java'
+        }
         resources {
-	    srcDir 'src/main/resources'
-	}
+            srcDir 'src/main/resources'
+        }
     }
 }
 
-build.dependsOn(shadowJar)
+shadowJar {
+    relocate('com.sk89q.squirrelid', 'com.sk89q.worldguard.util.profile')
+}
+
+build.dependsOn(shadowJar { classifier = null })

--- a/worldguard-legacy/build.gradle
+++ b/worldguard-legacy/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    compile project(':worldguard-core')
+    compile project(path: ':worldguard-core', configuration: 'shadow')
     compile 'org.bukkit:bukkit:1.13-R0.1-SNAPSHOT'
     compile 'com.sk89q.worldedit:worldedit-bukkit:7.0.0-SNAPSHOT'
     compile ('com.sk89q:commandbook:2.3') {
@@ -47,7 +47,6 @@ shadowJar {
     }
 
     relocate('org.flywaydb', 'com.sk89q.worldguard.internal.flywaydb')
-    relocate('com.sk89q.squirrelid', 'com.sk89q.worldguard.util.profile')
     relocate('org.json.simple', 'com.sk89q.worldguard.util.jsonsimple')
 
 }


### PR DESCRIPTION
This allows projects depending on core to properly use the ProfileService and ProfileResolver without themselves relocating the package.


So, essentially this solution would make the relocated version of SquirrelID part of the public API, so other projects can use them without having to depend on `-dist` version of worldguard-legacy.
This also means a small change for worldguard-legacy, namely that it has to depend on the shadow version of -core to correctly include the relocated squirrelid in its own shadowjar. (other projects that depend on maven artifacts won't have this issue, only -legacy has it since it has a `project()` dependency.)