### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,17 @@
-/.classpath
-/.project
-/.settings
-/target
+.classpath
+.project
+.settings/
+target/
 
 .DS_Store
 
 **/*.iml
 **/.idea
 
-/bin
-/dependency-reduced-pom.xml
+bin/
+dependency-reduced-pom.xml
 *-private.sh
 
-/.gradle
-**/build
+.gradle/
+**/build/
 out/


### PR DESCRIPTION
Using Github Desktop on Windows, file paths with a leading slash do not seem to match anything. This commit changes the gitignore entries to a more widely supported format.