### PR TITLE
Remove most usages of AsyncCommandHelper for new AsyncCommandBuilder.

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/FlagHelperBox.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/FlagHelperBox.java
@@ -82,7 +82,7 @@ class FlagHelperBox extends PaginationBox {
     private final RegionPermissionModel perms;
 
     FlagHelperBox(World world, ProtectedRegion region, RegionPermissionModel perms) {
-        super("Flags for " + region.getId(), "/rg flags -w " + world.getName() + " " + region.getId() + " %page%");
+        super("Flags for " + region.getId(), "/rg flags -w " + world.getName() + " -p %page% " + region.getId());
         this.world = world;
         this.region = region;
         this.perms = perms;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/task/RegionManagerLoader.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/task/RegionManagerLoader.java
@@ -28,16 +28,16 @@ import java.util.concurrent.Callable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class RegionManagerReloader implements Callable<Collection<RegionManager>> {
+public class RegionManagerLoader implements Callable<Collection<RegionManager>> {
 
     private final Collection<RegionManager> managers;
 
-    public RegionManagerReloader(Collection<RegionManager> managers) {
+    public RegionManagerLoader(Collection<RegionManager> managers) {
         checkNotNull(managers);
         this.managers = managers;
     }
 
-    public RegionManagerReloader(RegionManager... manager) {
+    public RegionManagerLoader(RegionManager... manager) {
         this(Arrays.asList(manager));
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/util/DomainInputResolver.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/util/DomainInputResolver.java
@@ -139,6 +139,10 @@ public class DomainInputResolver implements Callable<DefaultDomain> {
         return domain;
     }
 
+    /**
+     * @deprecated was only used for Future transformation. Can be replaced with {@code region.getOwners()::addAll} (or getMembers).
+     */
+    @Deprecated
     public Function<DefaultDomain, DefaultDomain> createAddAllFunction(final DefaultDomain target) {
         return domain -> {
             target.addAll(domain);
@@ -146,6 +150,10 @@ public class DomainInputResolver implements Callable<DefaultDomain> {
         };
     }
 
+    /**
+     * @deprecated was only used for Future transformation. Can be replaced with {@code region.getOwners()::removeAll} (or getMembers).
+     */
+    @Deprecated
     public Function<DefaultDomain, DefaultDomain> createRemoveAllFunction(final DefaultDomain target) {
         return domain -> {
             target.removeAll(domain);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/util/WorldGuardExceptionConverter.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/util/WorldGuardExceptionConverter.java
@@ -19,16 +19,15 @@
 
 package com.sk89q.worldguard.util;
 
-import com.google.common.collect.ImmutableList;
+import com.sk89q.minecraft.util.commands.CommandException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.internal.command.exception.ExceptionConverterHelper;
 import com.sk89q.worldedit.internal.command.exception.ExceptionMatch;
 import com.sk89q.worldedit.util.auth.AuthorizationException;
-import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.component.InvalidComponentException;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.managers.storage.StorageException;
 import com.sk89q.worldguard.protection.util.UnresolvedNamesException;
-import org.enginehub.piston.exception.CommandException;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.RejectedExecutionException;
@@ -41,7 +40,7 @@ public class WorldGuardExceptionConverter extends ExceptionConverterHelper {
     private static final Pattern numberFormat = Pattern.compile("^For input string: \"(.*)\"$");
 
     private CommandException newCommandException(String message, Throwable cause) {
-        return new CommandException(TextComponent.of(String.valueOf(message)), cause, ImmutableList.of());
+        return new CommandException(message, cause);
     }
 
     @ExceptionMatch
@@ -54,6 +53,11 @@ public class WorldGuardExceptionConverter extends ExceptionConverterHelper {
         } else {
             throw newCommandException("Number expected; string given.", e);
         }
+    }
+
+    @ExceptionMatch
+    public void convert(InvalidComponentException e) throws CommandException {
+        throw newCommandException(e.getMessage(), e);
     }
 
     @ExceptionMatch

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/BukkitDebugHandler.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/BukkitDebugHandler.java
@@ -95,9 +95,8 @@ public class BukkitDebugHandler implements DebugHandler {
             log.info("Event report for " + receiver.getName() + ":\n\n" + result);
 
             plugin.checkPermission(receiver, "worldguard.debug.pastebin");
-            ActorCallbackPaste
-                    .pastebin(WorldGuard.getInstance().getSupervisor(), plugin.wrapCommandSender(receiver), result,
-                            "Event debugging report: %s.txt", WorldGuard.getInstance().getExceptionConverter());
+            ActorCallbackPaste.pastebin(WorldGuard.getInstance().getSupervisor(), plugin.wrapCommandSender(receiver),
+                    result, "Event debugging report: %s.txt");
         } else {
             receiver.sendMessage(result.replaceAll("(?m)^", ChatColor.AQUA.toString()));
 


### PR DESCRIPTION
Helper suffers from race conditions for short-lived tasks, leading to
some poor UX conditions such as errors not propagating to the user
(because the exception handler wasn't attached to the future yet), or
lack of success messages.

This commit replaces that system by a Builder which takes a callable to
begin, and then takes supervisor, delay message, and the success and
failure messages and handlers as parts of the builder. The success and
failure handlers wrap the callable itself before submitting to the
executor so they will always be run. The supervisor and delay are added
as listeners to the future since they aren't required if the task is
sufficiently short-lived (and to maintain compatibility with the classes
which are now in WorldEdit).