### PR TITLE
Add Custom Domains for plugin stuff

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/WorldGuard.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/WorldGuard.java
@@ -24,6 +24,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.worldguard.domains.registry.CustomDomainRegistry;
+import com.sk89q.worldguard.domains.registry.SimpleCustomDomainRegistry;
 import com.sk89q.worldguard.util.profile.cache.HashMapCache;
 import com.sk89q.worldguard.util.profile.cache.ProfileCache;
 import com.sk89q.worldguard.util.profile.cache.SQLiteCache;
@@ -55,6 +57,7 @@ public final class WorldGuard {
 
     private WorldGuardPlatform platform;
     private final SimpleFlagRegistry flagRegistry = new SimpleFlagRegistry();
+    private final CustomDomainRegistry customDomainRegsitry = new SimpleCustomDomainRegistry();
     private final Supervisor supervisor = new SimpleSupervisor();
     private ProfileCache profileCache;
     private ProfileService profileService;
@@ -64,6 +67,7 @@ public final class WorldGuard {
     static {
         Flags.registerAll();
     }
+
 
     public static WorldGuard getInstance() {
         return instance;
@@ -113,6 +117,15 @@ public final class WorldGuard {
      */
     public FlagRegistry getFlagRegistry() {
         return this.flagRegistry;
+    }
+
+    /**
+     * Get the custom domain registry.
+     * 
+     * @return the domain registry
+     */
+    public CustomDomainRegistry getCustomDomainRegistry() {
+        return this.customDomainRegsitry;
     }
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomain.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomain.java
@@ -1,0 +1,22 @@
+package com.sk89q.worldguard.domains.registry;
+
+public class CustomDomain {
+    // Im not sure how to make this. It could be a simple "String" but maybe we need some other stuff like default
+    // behavior
+    private String name;
+    private String description;
+    private String registeredPlugin;
+
+    public CustomDomain(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public CustomDomain(String customDomainId) {
+        this(customDomainId, null);
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomain.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomain.java
@@ -1,3 +1,22 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldguard.domains.registry;
 
 public class CustomDomain {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainConflictException.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainConflictException.java
@@ -1,0 +1,9 @@
+package com.sk89q.worldguard.domains.registry;
+
+public class CustomDomainConflictException extends RuntimeException {
+
+    public CustomDomainConflictException(String message) {
+        super(message);
+    }
+
+}

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainConflictException.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainConflictException.java
@@ -1,3 +1,22 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldguard.domains.registry;
 
 public class CustomDomainConflictException extends RuntimeException {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainRegistry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainRegistry.java
@@ -1,11 +1,27 @@
-package com.sk89q.worldguard.domains.registry;
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
-import com.sk89q.worldguard.protection.flags.Flag;
+package com.sk89q.worldguard.domains.registry;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 public interface CustomDomainRegistry extends Iterable<CustomDomain> {
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainRegistry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/CustomDomainRegistry.java
@@ -1,0 +1,70 @@
+package com.sk89q.worldguard.domains.registry;
+
+import com.sk89q.worldguard.protection.flags.Flag;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public interface CustomDomainRegistry extends Iterable<CustomDomain> {
+
+    /**
+     * Register a new custom Domain.
+     *
+     * <p>There may be an appropriate time to register this. If domains are
+     * registered outside this time, then an exception may be thrown.</p>
+     *
+     * @param customDomain the domain
+     * @throws CustomDomainConflictException Thrown when an existing domain exists with the same name
+     * @throws IllegalStateException If it is not the right time to register new domains
+     */
+    void register(CustomDomain customDomain) throws CustomDomainConflictException;
+
+    /**
+     * Register a collection of domains.
+     *
+     * <p>There may be an appropriate time to register domains. If domains are
+     * registered outside this time, then an exception may be thrown.</p>
+     *
+     * <p>If there is a domain conflict, then an error will be logged but
+     * no exception will be thrown.</p>
+     *
+     * @param customDomains a collection of flags
+     * @throws IllegalStateException If it is not the right time to register new flags
+     */
+    void registerAll(Collection<CustomDomain> customDomains);
+
+    /**
+     * Get a domain by its name.
+     *
+     * @param name The name
+     * @return The domain, if it has been registered
+     */
+    @Nullable
+    CustomDomain get(String name);
+
+    /**
+     * Get all domains
+     *
+     * @return All domains
+     */
+    List<CustomDomain> getAll();
+
+    /*
+     * Unmarshal a raw map of values into a map of flags with their
+     * unmarshalled values.
+     *
+     * @param rawValues The raw values map
+     * @param createUnknown Whether "just in time" flags should be created for unknown flags
+     * @return The unmarshalled flag values map
+     */
+//    Map<Flag<?>, Object> unmarshal(Map<String, Object> rawValues, boolean createUnknown);
+
+    /**
+     * Get the number of registered flags.
+     *
+     * @return The number of registered flags
+     */
+    int size();
+}

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/SimpleCustomDomainRegistry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/SimpleCustomDomainRegistry.java
@@ -1,3 +1,22 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.sk89q.worldguard.domains.registry;
 
 import com.google.common.collect.Iterators;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/SimpleCustomDomainRegistry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/registry/SimpleCustomDomainRegistry.java
@@ -1,0 +1,106 @@
+package com.sk89q.worldguard.domains.registry;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SimpleCustomDomainRegistry implements CustomDomainRegistry {
+    private static final Logger log = Logger.getLogger(CustomDomainRegistry.class.getCanonicalName());
+
+    private final Object lock = new Object();
+    private final ConcurrentMap<String, CustomDomain> domains = Maps.newConcurrentMap();
+    private boolean initialized = false;
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public void setInitialized(boolean initialized) {
+        this.initialized = initialized;
+    }
+
+    @Override
+    public void register(CustomDomain customDomain) throws CustomDomainConflictException {
+        synchronized (lock) {
+            if(initialized) {
+                throw new IllegalStateException("New custom domains cannot be registered at this time");
+            }
+
+            forceRegister(customDomain);
+        }
+    }
+
+    @Override
+    public void registerAll(Collection<CustomDomain> customDomains) {
+        synchronized (lock) {
+            for (CustomDomain domain : customDomains) {
+                try {
+                    register(domain);
+                } catch (CustomDomainConflictException e) {
+                    log.log(Level.WARNING, e.getMessage());
+                }
+            }
+        }
+    }
+
+    private CustomDomain forceRegister(CustomDomain domain) throws CustomDomainConflictException {
+        checkNotNull(domain, "domain");
+        checkNotNull(domain.getName(), "domain.getName()");
+
+        synchronized (lock) {
+            String name = domain.getName().toLowerCase();
+            if(domains.containsKey(name)) {
+                throw new CustomDomainConflictException("A domain already exists by the name " + name);
+            }
+
+            domains.put(name, domain);
+        }
+
+        return domain;
+    }
+
+    @Nullable
+    @Override
+    public CustomDomain get(String name) {
+        checkNotNull(name);
+        return domains.get(name.toLowerCase());
+    }
+
+    @Override
+    public List<CustomDomain> getAll() {
+        return Lists.newArrayList(this.domains.values());
+    }
+
+    private CustomDomain getOrCreate(String name) {
+        CustomDomain domain = get(name);
+
+        if(domain != null) {
+            return domain;
+        }
+
+        synchronized (lock) {
+            domain = get(name);
+            return domain != null ? domain : forceRegister(new CustomDomain(name));
+        }
+    }
+
+    @Override
+    public int size() {
+        return domains.size();
+    }
+
+    @Override
+    public Iterator<CustomDomain> iterator() {
+        return Iterators.unmodifiableIterator(domains.values().iterator());
+    }
+}

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/registry/FlagRegistry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/registry/FlagRegistry.java
@@ -58,7 +58,7 @@ public interface FlagRegistry extends Iterable<Flag<?>> {
     void registerAll(Collection<Flag<?>> flags);
 
     /**
-     * Get af flag by its name.
+     * Get a flag by its name.
      *
      * @param name The name
      * @return The flag, if it has been registered

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
@@ -33,6 +33,7 @@ import com.sk89q.worldguard.util.Normal;
 import java.awt.geom.Area;
 import java.awt.geom.Line2D;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,6 +63,7 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
     private DefaultDomain owners = new DefaultDomain();
     private DefaultDomain members = new DefaultDomain();
     private ConcurrentMap<Flag<?>, Object> flags = new ConcurrentHashMap<>();
+    private ConcurrentMap<String, DefaultDomain> customDomains = new ConcurrentHashMap<>();
     private boolean dirty = true;
 
     /**
@@ -258,6 +260,35 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
         checkNotNull(members);
         setDirty(true);
         this.members = new DefaultDomain(members);
+    }
+
+    /**
+     * Get the map of domains that contains custom registered domains
+     *
+     * @return the map of domains
+     */
+    public Map<String, DefaultDomain> getCustomDomains() {
+        return Collections.unmodifiableMap(customDomains);
+    }
+
+    /**
+     * Get one custom domains from the name
+     *
+     * @return the domain
+     */
+    public DefaultDomain getCustomDomain(String name) {
+        checkNotNull(name);
+        return customDomains.get(name.toLowerCase());
+    }
+
+    /**
+     * Set the custom domains
+     */
+    public void setCustomDomains(Map<String, DefaultDomain> domains) {
+        checkNotNull(domains);
+        setDirty(true);
+        customDomains.clear();
+        domains.forEach((name, domain) -> customDomains.put(name, new DefaultDomain(domain)));
     }
 
     /**
@@ -471,6 +502,7 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
         checkNotNull(other);
         setMembers(other.getMembers());
         setOwners(other.getOwners());
+        setCustomDomains(other.getCustomDomains());
         setFlags(other.getFlags());
         setPriority(other.getPriority());
         try {


### PR DESCRIPTION
Idea:
Allow plugins to register their own custom domains to store player and group informations beside member and owner group.

The following stuff should work:

- Register CustomDomains with WorldGuard.getInstance().getCustomDomainRegistry().register(..);
- Save and load the CustomDomains from the yml-file. (sql doesn't work right now)
- Get the customDomain from the ProtectedRegion.

TODO:

- add something like RegionQuery$testDomain and ApplicableRegionSet$containsDomain. I'm not entirely sure how to implement it in WorldGuard. Help requested. My idea (for external plugin usage is something like: 
boolean RegionQuery.testDomain(localPlayer, "myPluginDomain"); or 
List<String> RegionQuery.queryDomains(localPlayer);
- sql stuff (I can implement that too but I want to be sure that the existing stuff is okay)
- Is the CustomDomain class necessary? The Registry could only be a Set<String> but maybe there could be some additional stuff for such CustomDomains.
- Maybe the current CustomDomain implementation with DefaultDomains could be expanded to allow users to create own contexts. Is this a thing? Or only as transient domain?

Thanks for all the stuff :)