### PR TITLE
Add entity placing and breaking flags (Fixes WORLDGUARD-4080)

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -66,6 +66,7 @@ import org.bukkit.event.vehicle.VehicleExitEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handle events that need to be processed by region protection.
@@ -300,6 +301,7 @@ public class RegionProtectionListener extends AbstractListener {
 
         Location target = event.getTarget();
         EntityType type = event.getEffectiveType();
+        com.sk89q.worldedit.world.entity.EntityType weType = BukkitAdapter.adapt(type);
 
         RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
         RegionAssociable associable = createRegionAssociable(event.getCause());
@@ -312,7 +314,7 @@ public class RegionProtectionListener extends AbstractListener {
             canSpawn = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.PLACE_VEHICLE));
             what = "place vehicles";
 
-        /* Item pickup */
+        /* Item drops */
         } else if (event.getEntity() instanceof Item) {
             canSpawn = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.ITEM_DROP));
             what = "drop items";
@@ -329,11 +331,13 @@ public class RegionProtectionListener extends AbstractListener {
         /* Everything else */
         } else {
             canSpawn = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event));
+            what = "place " + type.name().replace('_', ' ').toLowerCase() + "s";
+        }
 
-            if (event.getEntity() instanceof Item) {
-                what = "drop items";
-            } else {
-                what = "place things";
+        if (!canSpawn) {
+            Set<com.sk89q.worldedit.world.entity.EntityType> entityTypes = query.queryValue(BukkitAdapter.adapt(target), associable, Flags.PLACE_ENTITY);
+            if (entityTypes != null && weType != null && entityTypes.contains(weType)) {
+                canSpawn = true;
             }
         }
 
@@ -351,6 +355,7 @@ public class RegionProtectionListener extends AbstractListener {
 
         Location target = event.getTarget();
         EntityType type = event.getEntity().getType();
+        com.sk89q.worldedit.world.entity.EntityType weType = BukkitAdapter.adapt(type);
         RegionAssociable associable = createRegionAssociable(event.getCause());
 
         RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
@@ -370,7 +375,14 @@ public class RegionProtectionListener extends AbstractListener {
         /* Everything else */
         } else {
             canDestroy = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event));
-            what = "break things";
+            what = "break " + type.name().replace('_', ' ').toLowerCase() + "s";
+        }
+
+        if (!canDestroy) {
+            Set<com.sk89q.worldedit.world.entity.EntityType> entityTypes = query.queryValue(BukkitAdapter.adapt(target), associable, Flags.DESTROY_ENTITY);
+            if (entityTypes != null && weType != null && entityTypes.contains(weType)) {
+                canDestroy = true;
+            }
         }
 
         if (!canDestroy) {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -80,6 +80,12 @@ public final class Flags {
     public static final StateFlag ITEM_DROP = register(new StateFlag("item-drop", true)); // Intentionally true
     public static final StateFlag EXP_DROPS = register(new StateFlag("exp-drops", true)); // Intentionally true
 
+    // These flags are similar to the ones above (used in tandem with BUILD),
+    // but they aren't checked at all if the player can build. Only if the
+    // player can't build thy are checked to see if the type is allowed
+    public static final SetFlag<EntityType> PLACE_ENTITY = register(new SetFlag<>("entity-place", new RegistryFlag<>(null, EntityType.REGISTRY)));
+    public static final SetFlag<EntityType> DESTROY_ENTITY = register(new SetFlag<>("entity-destroy", new RegistryFlag<>(null, EntityType.REGISTRY)));
+
     // These flags adjust behavior and are not checked in tandem with the
     // BUILD flag so they need to be TRUE for their defaults.
 


### PR DESCRIPTION
This implements two new flags (`entity-place` and `entity-destroy`) which allow specifying which entities can be placed or destroyed in a region even though the player does not have build rights. This resolves [issue 4080](https://dev.enginehub.org/youtrack/issue/WORLDGUARD-4080).

It also displays the actual entity name when placing or destroying is cancelled instead of a general "things", fixes a comment and removes an unnecessary check for drops (which is handled before already)