### PR TITLE
Prevent pushing pistons across region borders

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -357,7 +357,8 @@ public class EventAbstractionListener extends AbstractListener {
             for (int i = 0; i < blocks.size(); i++) {
                 Block existing = blocks.get(i);
                 if (existing.getPistonMoveReaction() == PistonMoveReaction.MOVE
-                    || existing.getPistonMoveReaction() == PistonMoveReaction.PUSH_ONLY) {
+                    || existing.getPistonMoveReaction() == PistonMoveReaction.PUSH_ONLY
+                    || existing.getType() == Material.PISTON || existing.getType() == Material.STICKY_PISTON) {
                     blocks.set(i, existing.getRelative(dir));
                 }
             }


### PR DESCRIPTION
Pistons are classified as not pushable regardless of their state, causing WorldGuard to not protect against them moving from inside region borders to outside region borders. This PR fixes that.