### PR TITLE
add mount/dismount vehicles/animals flags

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -47,6 +47,7 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -414,7 +415,15 @@ public class RegionProtectionListener extends AbstractListener {
             }
         /* Ridden on use */
         } else if (Entities.isRiddenOnUse(entity)) {
-            canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.RIDE, Flags.INTERACT));
+            StateFlag flagToCheck;
+            if (entity instanceof Tameable){
+                flagToCheck = Flags.MOUNT_ANIMALS;
+            }else {
+                flagToCheck = Flags.MOUNT_VEHICLES;
+            }
+            // backward compatibility – if Flag.RIDE is allowed, just allow
+            canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.RIDE, Flags.INTERACT))
+                || query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, flagToCheck));
             what = "ride that";
 
         /* Everything else */
@@ -511,13 +520,23 @@ public class RegionProtectionListener extends AbstractListener {
         if (!isRegionSupportEnabled(BukkitAdapter.adapt(vehicle.getWorld()))) return; // Region support disabled
         Entity exited = event.getExited();
 
-        if (vehicle instanceof Tameable && exited instanceof Player) {
+        if(exited instanceof Player){
             Player player = (Player) exited;
             LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+            StateFlag flagToCheck;
+            if (vehicle instanceof Tameable){
+                flagToCheck = Flags.DISMOUNT_ANIMALS;
+            } else {
+                flagToCheck = Flags.DISMOUNT_VEHICLES;
+            }
             if (!isWhitelisted(Cause.create(player), vehicle.getWorld(), false)) {
                 RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
                 Location location = vehicle.getLocation();
-                if (!query.testBuild(BukkitAdapter.adapt(location), localPlayer, Flags.RIDE, Flags.INTERACT)) {
+                // don't let the INTERACT flag override dismounting
+                // the player might need to interact with world objects while staying mounted (buttons, doors etc)
+                // for backward compatibility, still allow the old Flags.RIDE | Flags.INTERACT
+                if (!query.testBuild(BukkitAdapter.adapt(location), localPlayer, flagToCheck)
+                    && !query.testBuild(BukkitAdapter.adapt(location), localPlayer, Flags.RIDE, Flags.INTERACT)) {
                     long now = System.currentTimeMillis();
                     Long lastTime = WGMetadata.getIfPresent(player, DISEMBARK_MESSAGE_KEY, Long.class);
                     if (lastTime == null || now - lastTime >= LAST_MESSAGE_DELAY) {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -66,6 +66,10 @@ public final class Flags {
     public static final StateFlag DESTROY_VEHICLE = register(new StateFlag("vehicle-destroy", false));
     public static final StateFlag LIGHTER = register(new StateFlag("lighter", false));
     public static final StateFlag RIDE = register(new StateFlag("ride", false));
+    public static final StateFlag MOUNT_ANIMALS = register(new StateFlag("mount-animals", false));
+    public static final StateFlag MOUNT_VEHICLES = register(new StateFlag("mount-vehicles", false));
+    public static final StateFlag DISMOUNT_ANIMALS = register(new StateFlag("dismount-animals", false));
+    public static final StateFlag DISMOUNT_VEHICLES = register(new StateFlag("dismount-vehicles", false));
     public static final StateFlag POTION_SPLASH = register(new StateFlag("potion-splash", false));
     public static final StateFlag ITEM_FRAME_ROTATE = register(new StateFlag("item-frame-rotation", false));
     public static final StateFlag TRAMPLE_BLOCKS = register(new StateFlag("block-trampling", false));


### PR DESCRIPTION
This PR aims to address inconsistencies and unexpected surprises with the current `ride` region flag, while maintaining backward compatibility.

## Prevents players from dismounting both vehicles and animals in protected regions where `ride` is denied

Previously, in regions with the `ride` flag set to `deny`, players would be prevented from dismounting their animals inside because they cannot get back on. However, this does not apply to vehicles (e.g. minecarts), despite [the documentation](https://worldguard.enginehub.org/en/latest/regions/flags/#protection-related) stating the `ride` flag applies to both vehicles and animals. This can lead to other problems such as abandoned minecarts in rail systems clogging up the system because they cannot get back on after they exit.

## More granular flags for dismounting/mounting vehicles/animals

My proposed solution is to separate the animals and vehicles flags entirely, as well as decouple mounting and dismounting permissions. Examples of use:

- A metro system would have two global regions: one for tunnels, and one for station platforms. Tunnels would set `dismount-vehicles`  to `DENY` to prevent players from exiting while the cart is in transit between stations, while the platforms will have `mount-vehicles` and `dismount-vehicles` set to `ALLOW`.

- A adventure map / pvp arena that requires players to remain mounted in their horses at all times while within the region would set `dismount-animals` to `DENY` within the arena grounds, while setting a separate staging area (the entrance) to allow them to mount and dismount freely before entering the grounds.

## Don't let `interact` determine mounting/dismounting permissions

Currently, if the `interact` flag (meant for buttons and doors) is set to `ALLOW`, users will still be able to mount/dismount from minecarts. Since we already have `ride` (and with my PR, more granular permissions targeting vehicles specifically), I suggest removing the `interact` flag from the permissions query for vehicle entry and exit.

## Backward compatibility with the existing `ride` flag

If this granular permissions is favourable to you, I suggest deprecating the `ride` flag. For backwards compatibility, my implementation lets the existing `ride` flag override my new flags:

- If `dismount-vehicles` is set to `DENY` but `ride` is set to `ALLOW`, allow dismount;
- If `mount-vehicles` is set to `DENY` but `ride` is set to `ALLOW`, allow mounting.

This gives server admins time to revise their region flags without their players suddenly being unable to mount or dismount vehicles or animals after upgrading.