### PR TITLE
Add teleport-message flag

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitPlayer.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitPlayer.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.world.weather.WeatherType;
 import com.sk89q.worldedit.world.weather.WeatherTypes;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.util.MessagingUtil;
 import io.papermc.lib.PaperLib;
 import org.bukkit.BanList.Type;
 import org.bukkit.Bukkit;
@@ -190,9 +191,13 @@ public class BukkitPlayer extends com.sk89q.worldedit.bukkit.BukkitPlayer implem
         PaperLib.teleportAsync(getPlayer(), BukkitAdapter.adapt(location))
                 .thenApply(success -> {
                     if (success) {
-                        print(successMessage);
+                        if (successMessage != null && !successMessage.isEmpty()) {
+                            MessagingUtil.sendStringToChat(this, successMessage);
+                        }
                     } else {
-                        printError(failMessage);
+                        if (failMessage != null && !failMessage.isEmpty()) {
+                            printError(failMessage);
+                        }
                     }
                     return success;
                 });

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -1111,8 +1111,10 @@ public final class RegionCommands extends RegionCommandsBase {
             }
         }
 
-        player.teleport(teleportLocation,
-                "Teleported you to the region '" + existing.getId() + "'.",
+        String message = existing.getFlag(Flags.TELE_MESSAGE);
+        message = message == null ? Flags.TELE_MESSAGE.getDefault() : message;
+        message = message == null ? "" : message.replace("%id%", existing.getId());
+        player.teleport(teleportLocation, message,
                 "Unable to teleport to region '" + existing.getId() + "'.");
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -134,6 +134,8 @@ public final class Flags {
     public static final LocationFlag TELE_LOC = register(new LocationFlag("teleport", RegionGroup.MEMBERS));
     public static final LocationFlag SPAWN_LOC = register(new LocationFlag("spawn", RegionGroup.MEMBERS));
 
+    public static final StringFlag TELE_MESSAGE = register(new StringFlag("teleport-message", "\u00A7dTeleported you to the region '%id%'."));
+
     // idk?
     public static final StateFlag INVINCIBILITY = register(new StateFlag("invincible", false));
     public static final StateFlag FALL_DAMAGE = register(new StateFlag("fall-damage", true));


### PR DESCRIPTION
Adds the ability to set a custom teleport message with the teleport-message region flag instead of the hard coded message up to now.

The default behavior (if the flag isn't set) matches the old behavior.

The message can be disabled by setting an empty message.