### PR TITLE
Update to Spigot 1.16.1 

### DIFF
--- a/worldguard-bukkit/build.gradle.kts
+++ b/worldguard-bukkit/build.gradle.kts
@@ -24,8 +24,8 @@ repositories {
 dependencies {
     "compile"(project(":worldguard-core"))
     //"compile"(project(":worldguard-libs:bukkit"))
-    "api"("com.destroystokyo.paper:paper-api:1.15.2-R0.1-SNAPSHOT")
-    "implementation"("io.papermc:paperlib:1.0.2")
+    "api"("com.destroystokyo.paper:paper-api:1.16.1-R0.1-SNAPSHOT")
+    "implementation"("io.papermc:paperlib:1.0.4")
     "api"("com.sk89q.worldedit:worldedit-bukkit:${Versions.WORLDEDIT}") { isTransitive = false }
     "implementation"("com.sk89q:commandbook:2.3") { isTransitive = false }
     "implementation"("org.bstats:bstats-bukkit:1.7")
@@ -64,7 +64,7 @@ tasks.named<ShadowJar>("shadowJar") {
             include(dependency("org.bstats:bstats-bukkit:1.7"))
         }
         relocate ("io.papermc.lib", "com.sk89q.worldguard.bukkit.paperlib") {
-            include(dependency("io.papermc:paperlib:1.0.2"))
+            include(dependency("io.papermc:paperlib:1.0.4"))
         }
     }
 }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -261,8 +261,8 @@ public class RegionProtectionListener extends AbstractListener {
                 canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.CHEST_ACCESS));
                 what = "open that";
 
-            /* Beds */
-            } else if (Materials.isBed(type)) {
+            /* Beds or Respawn Anchor */
+            } else if (Materials.isBed(type) || type == Material.RESPAWN_ANCHOR) {
                 canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.INTERACT, Flags.SLEEP));
                 what = "sleep";
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -261,10 +261,15 @@ public class RegionProtectionListener extends AbstractListener {
                 canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.CHEST_ACCESS));
                 what = "open that";
 
-            /* Beds or Respawn Anchor */
-            } else if (Materials.isBed(type) || type == Material.RESPAWN_ANCHOR) {
+            /* Beds */
+            } else if (Materials.isBed(type)) {
                 canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.INTERACT, Flags.SLEEP));
                 what = "sleep";
+
+            /* Respawn Anchors */
+            } else if(type == Material.RESPAWN_ANCHOR) {
+                canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.INTERACT, Flags.RESPAWN_ANCHORS));
+                what = "use anchors";
 
             /* TNT */
             } else if (type == Material.TNT) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -328,12 +328,7 @@ public class RegionProtectionListener extends AbstractListener {
         /* Everything else */
         } else {
             canSpawn = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event));
-
-            if (event.getEntity() instanceof Item) {
-                what = "drop items";
-            } else {
-                what = "place things";
-            }
+            what = "place things";
         }
 
         if (!canSpawn) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -161,7 +161,6 @@ public final class Materials {
         MATERIAL_FLAGS.put(Material.CACTUS, 0);
         MATERIAL_FLAGS.put(Material.CLAY, 0);
         MATERIAL_FLAGS.put(Material.JUKEBOX, MODIFIED_ON_RIGHT);
-        MATERIAL_FLAGS.put(Material.OAK_FENCE, 0);
         MATERIAL_FLAGS.put(Material.PUMPKIN, 0);
         MATERIAL_FLAGS.put(Material.NETHERRACK, 0);
         MATERIAL_FLAGS.put(Material.SOUL_SAND, 0);
@@ -195,17 +194,10 @@ public final class Materials {
         MATERIAL_FLAGS.put(Material.PUMPKIN_STEM, 0);
         MATERIAL_FLAGS.put(Material.MELON_STEM, 0);
         MATERIAL_FLAGS.put(Material.VINE, 0);
-        MATERIAL_FLAGS.put(Material.SPRUCE_FENCE_GATE, MODIFIED_ON_RIGHT);
-        MATERIAL_FLAGS.put(Material.ACACIA_FENCE_GATE, MODIFIED_ON_RIGHT);
-        MATERIAL_FLAGS.put(Material.BIRCH_FENCE_GATE, MODIFIED_ON_RIGHT);
-        MATERIAL_FLAGS.put(Material.DARK_OAK_FENCE_GATE, MODIFIED_ON_RIGHT);
-        MATERIAL_FLAGS.put(Material.JUNGLE_FENCE_GATE, MODIFIED_ON_RIGHT);
-        MATERIAL_FLAGS.put(Material.OAK_FENCE_GATE, MODIFIED_ON_RIGHT);
         MATERIAL_FLAGS.put(Material.BRICK_STAIRS, 0);
         MATERIAL_FLAGS.put(Material.MYCELIUM, 0);
         MATERIAL_FLAGS.put(Material.LILY_PAD, 0);
         MATERIAL_FLAGS.put(Material.NETHER_BRICK, 0);
-        MATERIAL_FLAGS.put(Material.NETHER_BRICK_FENCE, 0);
         MATERIAL_FLAGS.put(Material.NETHER_BRICK_STAIRS, 0);
         MATERIAL_FLAGS.put(Material.ENCHANTING_TABLE, MODIFIED_ON_RIGHT);
         MATERIAL_FLAGS.put(Material.BREWING_STAND, MODIFIED_ON_RIGHT);
@@ -257,11 +249,6 @@ public final class Materials {
         MATERIAL_FLAGS.put(Material.IRON_TRAPDOOR, 0);
         MATERIAL_FLAGS.put(Material.RED_SANDSTONE, 0);
         MATERIAL_FLAGS.put(Material.RED_SANDSTONE_STAIRS, 0);
-        MATERIAL_FLAGS.put(Material.SPRUCE_FENCE, 0);
-        MATERIAL_FLAGS.put(Material.BIRCH_FENCE, 0);
-        MATERIAL_FLAGS.put(Material.JUNGLE_FENCE, 0);
-        MATERIAL_FLAGS.put(Material.DARK_OAK_FENCE, 0);
-        MATERIAL_FLAGS.put(Material.ACACIA_FENCE, 0);
         MATERIAL_FLAGS.put(Material.SPRUCE_DOOR, MODIFIED_ON_RIGHT);
         MATERIAL_FLAGS.put(Material.BIRCH_DOOR, MODIFIED_ON_RIGHT);
         MATERIAL_FLAGS.put(Material.JUNGLE_DOOR, MODIFIED_ON_RIGHT);
@@ -693,15 +680,72 @@ public final class Materials {
         MATERIAL_FLAGS.put(Material.SWEET_BERRIES, 0);
 
         // 1.15
-        try {
-            MATERIAL_FLAGS.put(Material.BEEHIVE, MODIFIED_ON_RIGHT);
-            MATERIAL_FLAGS.put(Material.BEE_NEST, MODIFIED_ON_RIGHT);
-            MATERIAL_FLAGS.put(Material.HONEY_BLOCK, 0);
-            MATERIAL_FLAGS.put(Material.HONEYCOMB_BLOCK, 0);
-            MATERIAL_FLAGS.put(Material.HONEY_BOTTLE, 0);
-            MATERIAL_FLAGS.put(Material.HONEYCOMB, 0);
-        } catch (NoSuchFieldError ignored) {
-        }
+        MATERIAL_FLAGS.put(Material.BEEHIVE, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.BEE_NEST, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.HONEY_BLOCK, 0);
+        MATERIAL_FLAGS.put(Material.HONEYCOMB_BLOCK, 0);
+        MATERIAL_FLAGS.put(Material.HONEY_BOTTLE, 0);
+        MATERIAL_FLAGS.put(Material.HONEYCOMB, 0);
+
+        // 1.16
+        MATERIAL_FLAGS.put(Material.ANCIENT_DEBRIS, 0);
+        MATERIAL_FLAGS.put(Material.BASALT, 0);
+        MATERIAL_FLAGS.put(Material.BLACKSTONE, 0);
+        MATERIAL_FLAGS.put(Material.CHAIN, 0);
+        MATERIAL_FLAGS.put(Material.CHISELED_NETHER_BRICKS, 0);
+        MATERIAL_FLAGS.put(Material.CHISELED_POLISHED_BLACKSTONE, 0);
+        MATERIAL_FLAGS.put(Material.CRACKED_NETHER_BRICKS, 0);
+        MATERIAL_FLAGS.put(Material.CRACKED_POLISHED_BLACKSTONE_BRICKS, 0);
+        MATERIAL_FLAGS.put(Material.CRIMSON_FUNGUS, 0);
+        MATERIAL_FLAGS.put(Material.CRIMSON_NYLIUM, 0);
+        MATERIAL_FLAGS.put(Material.CRIMSON_ROOTS, 0);
+        MATERIAL_FLAGS.put(Material.CRIMSON_TRAPDOOR, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.CRYING_OBSIDIAN, 0);
+        MATERIAL_FLAGS.put(Material.GILDED_BLACKSTONE, 0);
+        MATERIAL_FLAGS.put(Material.LODESTONE, 0);
+
+        MATERIAL_FLAGS.put(Material.NETHERITE_AXE, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_BLOCK, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_BOOTS, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_CHESTPLATE, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_HELMET, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_HOE, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_INGOT, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_LEGGINGS, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_PICKAXE, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_SCRAP, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_SHOVEL, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_SWORD, 0);
+
+        MATERIAL_FLAGS.put(Material.NETHER_GOLD_ORE, 0);
+        MATERIAL_FLAGS.put(Material.NETHER_SPROUTS, 0);
+        MATERIAL_FLAGS.put(Material.PIGLIN_BANNER_PATTERN, 0);
+        MATERIAL_FLAGS.put(Material.POLISHED_BASALT, 0);
+        MATERIAL_FLAGS.put(Material.POLISHED_BLACKSTONE, 0);
+        MATERIAL_FLAGS.put(Material.POLISHED_BLACKSTONE_BRICKS, 0);
+        MATERIAL_FLAGS.put(Material.POLISHED_BLACKSTONE_PRESSURE_PLATE, 0);
+        MATERIAL_FLAGS.put(Material.QUARTZ_BRICKS, 0);
+        MATERIAL_FLAGS.put(Material.RESPAWN_ANCHOR, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.SHROOMLIGHT, 0);
+        MATERIAL_FLAGS.put(Material.SOUL_CAMPFIRE, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.SOUL_FIRE, 0);
+        MATERIAL_FLAGS.put(Material.SOUL_LANTERN, 0);
+        MATERIAL_FLAGS.put(Material.SOUL_SOIL, 0);
+        MATERIAL_FLAGS.put(Material.SOUL_TORCH, 0);
+        MATERIAL_FLAGS.put(Material.SOUL_WALL_TORCH, 0);
+        MATERIAL_FLAGS.put(Material.TARGET, 0);
+        MATERIAL_FLAGS.put(Material.TWISTING_VINES, 0);
+        MATERIAL_FLAGS.put(Material.TWISTING_VINES_PLANT, 0);
+
+        MATERIAL_FLAGS.put(Material.WARPED_FUNGUS, 0);
+        MATERIAL_FLAGS.put(Material.WARPED_FUNGUS_ON_A_STICK, 0);
+        MATERIAL_FLAGS.put(Material.WARPED_NYLIUM, 0);
+        MATERIAL_FLAGS.put(Material.WARPED_ROOTS, 0);
+        MATERIAL_FLAGS.put(Material.WARPED_TRAPDOOR, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.WARPED_WART_BLOCK, 0);
+        MATERIAL_FLAGS.put(Material.WEEPING_VINES, 0);
+        MATERIAL_FLAGS.put(Material.WEEPING_VINES_PLANT, 0);
+
 
         // Fake tags
         for (Material m : shulkerBoxes) {
@@ -768,6 +812,12 @@ public final class Materials {
         }
         for (Material bannerPat : Tag.ITEMS_BANNERS.getValues()) {
             MATERIAL_FLAGS.put(bannerPat, 0);
+        }
+        for (Material fenceGate : Tag.FENCE_GATES.getValues()) {
+            MATERIAL_FLAGS.put(fenceGate, MODIFIED_ON_RIGHT);
+        }
+        for (Material fence : Tag.FENCES.getValues()) {
+            MATERIAL_FLAGS.put(fence, 0);
         }
         Stream.concat(Stream.concat(
                 Tag.CORAL_BLOCKS.getValues().stream(),
@@ -882,7 +932,8 @@ public final class Materials {
      * @return true if a mushroom block
      */
     public static boolean isMushroom(Material material) {
-        return material == Material.RED_MUSHROOM || material == Material.BROWN_MUSHROOM;
+        return material == Material.RED_MUSHROOM || material == Material.BROWN_MUSHROOM
+                || material == Material.CRIMSON_FUNGUS || material == Material.WARPED_FUNGUS;
     }
 
     /**
@@ -1026,6 +1077,7 @@ public final class Materials {
             case FOX_SPAWN_EGG:
             case GHAST_SPAWN_EGG:
             case GUARDIAN_SPAWN_EGG:
+            case HOGLIN_SPAWN_EGG:
             case HORSE_SPAWN_EGG:
             case HUSK_SPAWN_EGG:
             case LLAMA_SPAWN_EGG:
@@ -1036,6 +1088,7 @@ public final class Materials {
             case PANDA_SPAWN_EGG:
             case PARROT_SPAWN_EGG:
             case PHANTOM_SPAWN_EGG:
+            case PIGLIN_SPAWN_EGG:
             case PIG_SPAWN_EGG:
             case PILLAGER_SPAWN_EGG:
             case POLAR_BEAR_SPAWN_EGG:
@@ -1051,6 +1104,7 @@ public final class Materials {
             case SLIME_SPAWN_EGG:
             case SQUID_SPAWN_EGG:
             case STRAY_SPAWN_EGG:
+            case STRIDER_SPAWN_EGG:
             case TRADER_LLAMA_SPAWN_EGG:
             case TROPICAL_FISH_SPAWN_EGG:
             case TURTLE_SPAWN_EGG:
@@ -1061,8 +1115,9 @@ public final class Materials {
             case WITCH_SPAWN_EGG:
             case WITHER_SKELETON_SPAWN_EGG:
             case WOLF_SPAWN_EGG:
+            case ZOGLIN_SPAWN_EGG:
             case ZOMBIE_HORSE_SPAWN_EGG:
-            case ZOMBIE_PIGMAN_SPAWN_EGG:
+            case ZOMBIFIED_PIGLIN_SPAWN_EGG:
             case ZOMBIE_SPAWN_EGG:
             case ZOMBIE_VILLAGER_SPAWN_EGG:
                 return true;
@@ -1113,6 +1168,8 @@ public final class Materials {
                 return EntityType.GHAST;
             case GUARDIAN_SPAWN_EGG:
                 return EntityType.GUARDIAN;
+            case HOGLIN_SPAWN_EGG:
+                return EntityType.HOGLIN;
             case HORSE_SPAWN_EGG:
                 return EntityType.HORSE;
             case HUSK_SPAWN_EGG:
@@ -1133,6 +1190,8 @@ public final class Materials {
                 return EntityType.PARROT;
             case PHANTOM_SPAWN_EGG:
                 return EntityType.PHANTOM;
+            case PIGLIN_SPAWN_EGG:
+                return EntityType.PIGLIN;
             case PILLAGER_SPAWN_EGG:
                 return EntityType.PILLAGER;
             case POLAR_BEAR_SPAWN_EGG:
@@ -1161,6 +1220,8 @@ public final class Materials {
                 return EntityType.SQUID;
             case STRAY_SPAWN_EGG:
                 return EntityType.STRAY;
+            case STRIDER_SPAWN_EGG:
+                return EntityType.STRIDER;
             case TRADER_LLAMA_SPAWN_EGG:
                 return EntityType.TRADER_LLAMA;
             case TROPICAL_FISH_SPAWN_EGG:
@@ -1183,8 +1244,8 @@ public final class Materials {
                 return EntityType.WOLF;
             case ZOMBIE_HORSE_SPAWN_EGG:
                 return EntityType.ZOMBIE_HORSE;
-            case ZOMBIE_PIGMAN_SPAWN_EGG:
-                return EntityType.PIG_ZOMBIE;
+            case ZOMBIFIED_PIGLIN_SPAWN_EGG:
+                return EntityType.ZOMBIFIED_PIGLIN;
             case ZOMBIE_SPAWN_EGG:
                 return EntityType.ZOMBIE;
             case ZOMBIE_VILLAGER_SPAWN_EGG:
@@ -1240,24 +1301,15 @@ public final class Materials {
         if (Tag.BUTTONS.isTagged(material)
                 || Tag.DOORS.isTagged(material)
                 || Tag.WOODEN_PRESSURE_PLATES.isTagged(material)
-                || Tag.WOODEN_TRAPDOORS.isTagged(material)) {
+                || Tag.WOODEN_TRAPDOORS.isTagged(material)
+                || Tag.FENCE_GATES.isTagged(material)
+                || Tag.PRESSURE_PLATES.isTagged(material)
+                || Tag.ANVIL.isTagged(material)) {
             return true;
         }
         switch (material) {
             case LEVER:
             case LECTERN:
-            case ACACIA_FENCE_GATE:
-            case DARK_OAK_FENCE_GATE:
-            case JUNGLE_FENCE_GATE:
-            case BIRCH_FENCE_GATE:
-            case SPRUCE_FENCE_GATE:
-            case OAK_FENCE_GATE:
-            case LIGHT_WEIGHTED_PRESSURE_PLATE:
-            case HEAVY_WEIGHTED_PRESSURE_PLATE:
-            case STONE_PRESSURE_PLATE:
-            case ANVIL:
-            case DAMAGED_ANVIL:
-            case CHIPPED_ANVIL:
             case ENCHANTING_TABLE:
             case BELL:
             case LOOM:
@@ -1425,6 +1477,7 @@ public final class Materials {
                 switch (targetMaterial) {
                     case GRASS_BLOCK:
                     case CAMPFIRE:
+                    case SOUL_CAMPFIRE:
                         return true;
                 }
                 return false;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -1300,7 +1300,6 @@ public final class Materials {
     public static boolean isUseFlagApplicable(Material material) {
         if (Tag.BUTTONS.isTagged(material)
                 || Tag.DOORS.isTagged(material)
-                || Tag.WOODEN_PRESSURE_PLATES.isTagged(material)
                 || Tag.WOODEN_TRAPDOORS.isTagged(material)
                 || Tag.FENCE_GATES.isTagged(material)
                 || Tag.PRESSURE_PLATES.isTagged(material)

--- a/worldguard-bukkit/src/main/resources/plugin.yml
+++ b/worldguard-bukkit/src/main/resources/plugin.yml
@@ -3,4 +3,4 @@ main: com.sk89q.worldguard.bukkit.WorldGuardPlugin
 version: "${internalVersion}"
 depend: [WorldEdit]
 softdepend: [CommandBook]
-api-version: 1.13
+api-version: 1.16

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -60,6 +60,7 @@ public final class Flags {
     public static final StateFlag DAMAGE_ANIMALS = register(new StateFlag("damage-animals", false));
     public static final StateFlag PVP = register(new StateFlag("pvp", false));
     public static final StateFlag SLEEP = register(new StateFlag("sleep", false));
+    public static final StateFlag RESPAWN_ANCHORS = register(new StateFlag("respawn-anchors", false));
     public static final StateFlag TNT = register(new StateFlag("tnt", false));
     public static final StateFlag CHEST_ACCESS = register(new StateFlag("chest-access", false));
     public static final StateFlag PLACE_VEHICLE = register(new StateFlag("vehicle-place", false));


### PR DESCRIPTION
Updated to 1.16.1
With the changed names from zombie pigmans to zombified piglins it's not easily possible to maintain backwards compatiblity to 1.15.

Updated PaperLib to 1.0.4 too.