### PR TITLE
Add Weeping Vines and Twisting Vines to vine-growth flag

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
@@ -597,7 +597,7 @@ public class WorldGuardBlockListener implements Listener {
             }
         }
 
-        if (newType == Material.VINE || newType == Material.KELP) {
+        if (Materials.isVine(newType)) {
             if (wcfg.disableVineGrowth) {
                 event.setCancelled(true);
                 return;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -1287,6 +1287,19 @@ public final class Materials {
     }
 
     /**
+     * Test whether the material should be handled as vine. Used by the vine-growth flag
+     * @param newType the material
+     * @return true if the material should be handled as vine
+     */
+    public static boolean isVine(Material newType) {
+        return newType == Material.VINE ||
+                newType == Material.KELP ||
+                newType == Material.TWISTING_VINES ||
+                newType == Material.WEEPING_VINES;
+
+    }
+
+    /**
      * Test whether the given material is affected by
      * {@link Flags#USE}.
      *


### PR DESCRIPTION
Fix for https://github.com/EngineHub/WorldGuard/issues/1594