### PR TITLE
Fix chest-access flag for players taking book from lecterns

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -1084,7 +1084,6 @@ public class EventAbstractionListener extends AbstractListener {
     @EventHandler(ignoreCancelled = true)
     public void onTakeLecternBook(PlayerTakeLecternBookEvent event) {
         final UseBlockEvent useEvent = new UseBlockEvent(event, create(event.getPlayer()), event.getLectern().getBlock());
-        useEvent.getRelevantFlags().add(Flags.CHEST_ACCESS);
         Events.fireToCancel(event, useEvent);
     }
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -58,8 +58,10 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
+import org.bukkit.event.Event;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerTakeLecternBookEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 
 import java.util.ArrayList;
@@ -260,6 +262,11 @@ public class RegionProtectionListener extends AbstractListener {
             } else if (Materials.isInventoryBlock(type)) {
                 canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.CHEST_ACCESS));
                 what = "open that";
+
+            /* Inventory for blocks with the possibility to be only use, e.g. lectern */
+            } else if (handleAsInventoryUsage(event.getOriginalEvent())) {
+                canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.CHEST_ACCESS));
+                what = "take that";
 
             /* Beds */
             } else if (Materials.isBed(type)) {
@@ -550,6 +557,16 @@ public class RegionProtectionListener extends AbstractListener {
             flags[flag.length + i] = extra.get(i);
         }
         return flags;
+    }
+
+    /**
+     * Check if that event should be handled as inventory usage, e.g. if a player takes a book from a lectern
+     *
+     * @param event the event to handle
+     * @return whether it should be handled as inventory usage
+     */
+    private static boolean handleAsInventoryUsage(Event event) {
+        return event instanceof PlayerTakeLecternBookEvent;
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/EngineHub/WorldGuard/issues/1601

Based on the event it's considered to be a chest-access event. It's not necessary to check use at it's own. The player has to open the book before he can take the book from the gui. 
The new behavior should match chests, furnaces and other chest-access related things.