### PR TITLE
Added method to convert a ProtectedRegion to a WorldEdit's RegionSelector

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
@@ -31,15 +31,13 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Polygonal2DRegion;
 import com.sk89q.worldedit.regions.Region;
-import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
-import com.sk89q.worldedit.regions.selector.Polygonal2DRegionSelector;
+import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.util.formatting.component.ErrorFormat;
 import com.sk89q.worldedit.util.formatting.component.SubtleFormat;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
-import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
@@ -49,11 +47,7 @@ import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.FlagContext;
 import com.sk89q.worldguard.protection.flags.InvalidFlagFormat;
 import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
-import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
-import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.*;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -394,35 +388,15 @@ class RegionCommandsBase {
     protected static void setPlayerSelection(Actor actor, ProtectedRegion region, World world) throws CommandException {
         LocalSession session = WorldEdit.getInstance().getSessionManager().get(actor);
 
-        // Set selection
-        if (region instanceof ProtectedCuboidRegion) {
-            ProtectedCuboidRegion cuboid = (ProtectedCuboidRegion) region;
-            BlockVector3 pt1 = cuboid.getMinimumPoint();
-            BlockVector3 pt2 = cuboid.getMaximumPoint();
-
-            CuboidRegionSelector selector = new CuboidRegionSelector(world, pt1, pt2);
+        RegionSelector selector = region.toRegionSelector();
+        if (selector != null) {
+            selector.setWorld(world);
             session.setRegionSelector(world, selector);
             selector.explainRegionAdjust(actor, session);
-            actor.print("Region selected as a cuboid.");
-
-        } else if (region instanceof ProtectedPolygonalRegion) {
-            ProtectedPolygonalRegion poly2d = (ProtectedPolygonalRegion) region;
-            Polygonal2DRegionSelector selector = new Polygonal2DRegionSelector(
-                    world, poly2d.getPoints(),
-                    poly2d.getMinimumPoint().getBlockY(),
-                    poly2d.getMaximumPoint().getBlockY());
-            session.setRegionSelector(world, selector);
-            selector.explainRegionAdjust(actor, session);
-            actor.print("Region selected as a polygon.");
-
-        } else if (region instanceof GlobalProtectedRegion) {
-            throw new CommandException(
-                    "Can't select global regions! " +
-                            "That would cover the entire world.");
-
+            actor.print("Region selected as " + region.getType().getName());
         } else {
-            throw new CommandException("Unknown region type: " +
-                    region.getClass().getCanonicalName());
+            throw new CommandException("Can't select that region! " +
+                    "The region type '" + region.getType().getName() + "' can't be selected.");
         }
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
@@ -21,6 +21,7 @@ package com.sk89q.worldguard.protection.regions;
 
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.RegionSelector;
 
 import java.awt.geom.Area;
 import java.util.ArrayList;
@@ -100,4 +101,8 @@ public class GlobalProtectedRegion extends ProtectedRegion {
         return null;
     }
 
+    @Override
+    public RegionSelector toRegionSelector() {
+        return null;
+    }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
@@ -21,6 +21,7 @@ package com.sk89q.worldguard.protection.regions;
 
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 
 import java.awt.geom.Area;
@@ -98,6 +99,11 @@ public class GlobalProtectedRegion extends ProtectedRegion {
 
     @Override
     Area toArea() {
+        return null;
+    }
+
+    @Override
+    public Region toRegion() {
         return null;
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
@@ -23,6 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.RegionSelector;
+import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldguard.util.MathUtils;
 
 import java.awt.Rectangle;
@@ -141,6 +143,11 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
         int width = getMaximumPoint().getBlockX() - x + 1;
         int height = getMaximumPoint().getBlockZ() - z + 1;
         return new Area(new Rectangle(x, z, width, height));
+    }
+
+    @Override
+    public RegionSelector toRegionSelector() {
+        return new CuboidRegionSelector(null, getMinimumPoint(), getMaximumPoint());
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
@@ -23,10 +23,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldguard.util.MathUtils;
 
+import javax.annotation.Nullable;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
 import java.util.ArrayList;
@@ -143,6 +146,11 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
         int width = getMaximumPoint().getBlockX() - x + 1;
         int height = getMaximumPoint().getBlockZ() - z + 1;
         return new Area(new Rectangle(x, z, width, height));
+    }
+
+    @Override
+    public Region toRegion() {
+        return new CuboidRegion(null, getMinimumPoint(), getMaximumPoint());
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -24,6 +24,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.RegionSelector;
+import com.sk89q.worldedit.regions.selector.Polygonal2DRegionSelector;
 
 import java.awt.Polygon;
 import java.awt.geom.Area;
@@ -180,6 +182,11 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
 
         Polygon polygon = new Polygon(xCoords, yCoords, numPoints);
         return new Area(polygon);
+    }
+
+    @Override
+    public RegionSelector toRegionSelector() {
+        return new Polygonal2DRegionSelector(null, this.getPoints(), getMinimumPoint().getBlockY(), getMaximumPoint().getBlockY());
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -24,6 +24,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Polygonal2DRegion;
+import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.Polygonal2DRegionSelector;
 
@@ -185,8 +187,13 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
     }
 
     @Override
+    public Region toRegion() {
+        return new Polygonal2DRegion(null, this.getPoints(), minY, maxY);
+    }
+
+    @Override
     public RegionSelector toRegionSelector() {
-        return new Polygonal2DRegionSelector(null, this.getPoints(), getMinimumPoint().getBlockY(), getMaximumPoint().getBlockY());
+        return new Polygonal2DRegionSelector(null, this.getPoints(), minY, maxY);
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.Lists;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.domains.DefaultDomain;
@@ -665,6 +666,15 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
      * {@link #isPhysicalArea()} is false.
      *
      * @return the WorldEdit Region
+     */
+    @Nullable
+    public abstract Region toRegion();
+
+    /**
+     * Return the WorldEdit Region Selector, otherwise null if
+     * {@link #isPhysicalArea()} is false.
+     *
+     * @return the WorldEdit Region Selector
      */
     @Nullable
     public abstract RegionSelector toRegionSelector();

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.Lists;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.Flag;
@@ -658,6 +659,15 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
      * @return The shape version
      */
     abstract Area toArea();
+
+    /**
+     * Return the WorldEdit Region, otherwise null if
+     * {@link #isPhysicalArea()} is false.
+     *
+     * @return the WorldEdit Region
+     */
+    @Nullable
+    public abstract RegionSelector toRegionSelector();
 
     /**
      * @return <code>true</code> if this region should only be kept in memory and not be saved


### PR DESCRIPTION
Just a small addition to add a possibility to convert a ProtectedRegion to a RegionSelector.

I changed the command /rg select to the new method. It worked fine for my tests (cuboid, poly2d and global).

For my own plugins I want to mark a ProtectedRegion as selected sometimes. It could be a cool thing for new region types too.