### PR TITLE
Implement new alternative association mode to limit piston movement

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -160,7 +160,7 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
         disableExpDrops = getBoolean("protection.disable-xp-orb-drops", false);
         disableObsidianGenerators = getBoolean("protection.disable-obsidian-generators", false);
 
-        useBetterAssociationMode = getBoolean("protection.useBetterAssociationMode", false);
+        useMaxPriorityAssociation = getBoolean("protection.use-max-priority-association", false);
 
         blockPotions = new HashSet<>();
         for (String potionName : getStringList("gameplay.block-potions", null)) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -160,6 +160,8 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
         disableExpDrops = getBoolean("protection.disable-xp-orb-drops", false);
         disableObsidianGenerators = getBoolean("protection.disable-obsidian-generators", false);
 
+        useBetterAssociationMode = getBoolean("protection.useBetterAssociationMode", false);
+
         blockPotions = new HashSet<>();
         for (String potionName : getStringList("gameplay.block-potions", null)) {
             PotionEffectType effect = PotionEffectType.getByName(potionName);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
@@ -127,9 +127,10 @@ class AbstractListener implements Listener {
         } else if (rootCause instanceof Entity) {
             RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
             final Entity entity = (Entity) rootCause;
+            BukkitWorldConfiguration config =
+                    (BukkitWorldConfiguration) getWorldConfig(BukkitAdapter.adapt(entity.getWorld()));
             Location loc;
-            if (PaperLib.isPaper()
-                    && ((BukkitWorldConfiguration) getWorldConfig(BukkitAdapter.adapt(entity.getWorld()))).usePaperEntityOrigin) {
+            if (PaperLib.isPaper()  && config.usePaperEntityOrigin) {
                 loc = entity.getOrigin();
                 if (loc == null) {
                     loc = entity.getLocation();
@@ -137,11 +138,13 @@ class AbstractListener implements Listener {
             } else {
                 loc = entity.getLocation();
             }
-            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc.getWorld()), BukkitAdapter.adapt(loc));
+            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc),
+                    config.useMaxPriorityAssociation);
         } else if (rootCause instanceof Block) {
             RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
             Location loc = ((Block) rootCause).getLocation();
-            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc.getWorld()), BukkitAdapter.adapt(loc));
+            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc),
+                    getWorldConfig(BukkitAdapter.adapt(loc.getWorld())).useMaxPriorityAssociation);
         } else {
             return Associables.constant(Association.NON_MEMBER);
         }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
@@ -31,7 +31,7 @@ import com.sk89q.worldguard.bukkit.cause.Cause;
 import com.sk89q.worldguard.config.ConfigurationManager;
 import com.sk89q.worldguard.config.WorldConfiguration;
 import com.sk89q.worldguard.domains.Association;
-import com.sk89q.worldguard.protection.DelayedRegionOverlapAssociation;
+import com.sk89q.worldguard.protection.association.DelayedRegionOverlapAssociation;
 import com.sk89q.worldguard.protection.association.Associables;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.regions.RegionQuery;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
@@ -137,10 +137,11 @@ class AbstractListener implements Listener {
             } else {
                 loc = entity.getLocation();
             }
-            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc));
+            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc.getWorld()), BukkitAdapter.adapt(loc));
         } else if (rootCause instanceof Block) {
             RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
-            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(((Block) rootCause).getLocation()));
+            Location loc = ((Block) rootCause).getLocation();
+            return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc.getWorld()), BukkitAdapter.adapt(loc));
         } else {
             return Associables.constant(Association.NON_MEMBER);
         }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -171,6 +171,7 @@ public abstract class WorldConfiguration {
     public boolean strictEntitySpawn;
     public boolean ignoreHopperMoveEvents;
     public boolean breakDeniedHoppers;
+    public boolean useBetterAssociationMode;
     protected Map<String, Integer> maxRegionCounts;
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -171,7 +171,7 @@ public abstract class WorldConfiguration {
     public boolean strictEntitySpawn;
     public boolean ignoreHopperMoveEvents;
     public boolean breakDeniedHoppers;
-    public boolean useBetterAssociationMode;
+    public boolean useMaxPriorityAssociation;
     protected Map<String, Integer> maxRegionCounts;
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/DelayedRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/DelayedRegionOverlapAssociation.java
@@ -75,10 +75,19 @@ public class DelayedRegionOverlapAssociation implements RegionAssociable {
         if (source == null) {
             ApplicableRegionSet result = query.getApplicableRegions(location);
             source = result.getRegions();
-            if (useMaxPriorityAssociation)
-                maxPriority = source.stream().mapToInt(ProtectedRegion::getPriority).max().orElse(0);
-        }
+            assert source != null;
 
+            if (useMaxPriorityAssociation) {
+                int best = 0;
+                for (ProtectedRegion region : source) {
+                    int priority = region.getPriority();
+                    if (priority > best) {
+                        best = priority;
+                    }
+                }
+                maxPriority = best;
+            }
+        }
 
         for (ProtectedRegion region : regions) {
             if ((region.getId().equals(ProtectedRegion.GLOBAL_REGION) && source.isEmpty())) {
@@ -88,7 +97,9 @@ public class DelayedRegionOverlapAssociation implements RegionAssociable {
             if (source.contains(region)) {
                 if (useMaxPriorityAssociation) {
                     int priority = region.getPriority();
-                    if (priority == maxPriority) return Association.OWNER;
+                    if (priority == maxPriority) {
+                        return Association.OWNER;
+                    }
                 } else {
                     return Association.OWNER;
                 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/DelayedRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/DelayedRegionOverlapAssociation.java
@@ -51,7 +51,7 @@ public class DelayedRegionOverlapAssociation implements RegionAssociable {
 
     /**
      * Create a new instance.
-     *  @param query the query
+     * @param query the query
      * @param world the world
      * @param location the location
      */
@@ -70,6 +70,7 @@ public class DelayedRegionOverlapAssociation implements RegionAssociable {
             ApplicableRegionSet result = query.getApplicableRegions(location);
             source = result.getRegions();
         }
+        int maxPriority = source.stream().mapToInt(ProtectedRegion::getPriority).max().orElse(0);
 
         for (ProtectedRegion region : regions) {
             if ((region.getId().equals(ProtectedRegion.GLOBAL_REGION) && source.isEmpty())) {
@@ -79,7 +80,6 @@ public class DelayedRegionOverlapAssociation implements RegionAssociable {
             if (source.contains(region)) {
                 if (betterAssociationMode) {
                     int priority = region.getPriority();
-                    int maxPriority = source.stream().mapToInt(ProtectedRegion::getPriority).max().orElse(0);
                     if (priority == maxPriority) return Association.OWNER;
                 } else {
                     return Association.OWNER;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
@@ -1,0 +1,77 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection.association;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.sk89q.worldguard.domains.Association;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+
+public abstract class AbstractRegionOverlapAssociation implements RegionAssociable {
+
+    @Nullable
+    protected Set<ProtectedRegion> source;
+    private boolean useMaxPriorityAssociation;
+    private int maxPriority;
+
+    protected AbstractRegionOverlapAssociation(@Nullable Set<ProtectedRegion> source, boolean useMaxPriorityAssociation) {
+        this.source = source;
+        this.useMaxPriorityAssociation = useMaxPriorityAssociation;
+    }
+
+    protected void calcMaxPriority() {
+        checkNotNull(source);
+        int best = 0;
+        for (ProtectedRegion region : source) {
+            int priority = region.getPriority();
+            if (priority > best) {
+                best = priority;
+            }
+        }
+        this.maxPriority = best;
+    }
+
+    @Override
+    public Association getAssociation(List<ProtectedRegion> regions) {
+        checkNotNull(source);
+        for (ProtectedRegion region : regions) {
+            if ((region.getId().equals(ProtectedRegion.GLOBAL_REGION) && source.isEmpty())) {
+                return Association.OWNER;
+            }
+
+            if (source.contains(region)) {
+                if (useMaxPriorityAssociation) {
+                    int priority = region.getPriority();
+                    if (priority == maxPriority) {
+                        return Association.OWNER;
+                    }
+                } else {
+                    return Association.OWNER;
+                }
+            }
+        }
+
+        return Association.NON_MEMBER;
+    }
+}

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/DelayedRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/DelayedRegionOverlapAssociation.java
@@ -17,9 +17,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldguard.protection;
+package com.sk89q.worldguard.protection.association;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.domains.Association;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 
 import java.util.List;
@@ -30,18 +35,44 @@ import java.util.List;
  *
  * <p>This class only performs a spatial query if its
  * {@link #getAssociation(List)} method is called.</p>
- *
- * @deprecated Use {@link com.sk89q.worldguard.protection.association.DelayedRegionOverlapAssociation} instead. This class is mis-packaged.
  */
-@Deprecated
-public class DelayedRegionOverlapAssociation extends com.sk89q.worldguard.protection.association.DelayedRegionOverlapAssociation {
+public class DelayedRegionOverlapAssociation extends AbstractRegionOverlapAssociation {
+
+    private final RegionQuery query;
+    private final Location location;
+
     /**
      * Create a new instance.
      * @param query the query
      * @param location the location
      */
     public DelayedRegionOverlapAssociation(RegionQuery query, Location location) {
-        super(query, location, false);
+        this(query, location, false);
+    }
+
+    /**
+     * Create a new instance.
+     * @param query the query
+     * @param location the location
+     * @param useMaxPriorityAssociation whether to use the max priority from regions to determine association
+     */
+    public DelayedRegionOverlapAssociation(RegionQuery query, Location location, boolean useMaxPriorityAssociation) {
+        super(null, useMaxPriorityAssociation);
+        checkNotNull(query);
+        checkNotNull(location);
+        this.query = query;
+        this.location = location;
+    }
+
+    @Override
+    public Association getAssociation(List<ProtectedRegion> regions) {
+        if (source == null) {
+            ApplicableRegionSet result = query.getApplicableRegions(location);
+            source = result.getRegions();
+            calcMaxPriority();
+        }
+
+        return super.getAssociation(regions);
     }
 
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/RegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/RegionOverlapAssociation.java
@@ -19,30 +19,23 @@
 
 package com.sk89q.worldguard.protection.association;
 
-import com.sk89q.worldguard.domains.Association;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
-import java.util.List;
+import javax.annotation.Nonnull;
 import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Determines that the association to a region is {@code OWNER} if the input
  * region is in a set of source regions.
  */
-public class RegionOverlapAssociation implements RegionAssociable {
-
-    private final Set<ProtectedRegion> source;
-    private boolean useMaxPriorityAssociation;
-    private int maxPriority; // only used for useMaxPriorityAssociation
+public class RegionOverlapAssociation extends AbstractRegionOverlapAssociation {
 
     /**
      * Create a new instance.
      *
      * @param source set of regions that input regions must be contained within
      */
-    public RegionOverlapAssociation(Set<ProtectedRegion> source) {
+    public RegionOverlapAssociation(@Nonnull Set<ProtectedRegion> source) {
         this(source, false);
     }
 
@@ -52,40 +45,9 @@ public class RegionOverlapAssociation implements RegionAssociable {
      * @param source set of regions that input regions must be contained within
      * @param useMaxPriorityAssociation whether to use the max priority from regions to determine association
      */
-    public RegionOverlapAssociation(Set<ProtectedRegion> source, boolean useMaxPriorityAssociation) {
-        checkNotNull(source);
-        this.source = source;
-        this.useMaxPriorityAssociation = useMaxPriorityAssociation;
-        int best = 0;
-        for (ProtectedRegion region : source) {
-            int priority = region.getPriority();
-            if (priority > best) {
-                best = priority;
-            }
-        }
-        this.maxPriority = best;
-    }
-
-    @Override
-    public Association getAssociation(List<ProtectedRegion> regions) {
-        for (ProtectedRegion region : regions) {
-            if ((region.getId().equals(ProtectedRegion.GLOBAL_REGION) && source.isEmpty())) {
-                return Association.OWNER;
-            }
-
-            if (source.contains(region)) {
-                if (useMaxPriorityAssociation) {
-                    int priority = region.getPriority();
-                    if (priority == maxPriority) {
-                        return Association.OWNER;
-                    }
-                } else {
-                    return Association.OWNER;
-                }
-            }
-        }
-
-        return Association.NON_MEMBER;
+    public RegionOverlapAssociation(@Nonnull Set<ProtectedRegion> source, boolean useMaxPriorityAssociation) {
+        super(source, useMaxPriorityAssociation);
+        calcMaxPriority();
     }
 
 }


### PR DESCRIPTION
Currently pistons can pull stuff from a lower prioritized region into their own region.
E.g. a plot owner can steal blocks from a city if he uses pistons for that.

After some hints from wizjany I managed to change the method for the lookup of the regions in the DelayedRegionOverlapAssociation class.

However I don't feel good with the current implementation. Without a config option this would be some breaking changes, with the config option it seems a little bit ugly and should be cleaned up.