### PR TITLE
Fixed "null" output for invalid worldedit selections

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
@@ -245,14 +245,17 @@ class RegionCommandsBase {
      * @throws CommandException thrown on an error
      */
     protected static Region checkSelection(Actor actor) throws CommandException {
+        LocalSession localSession = WorldEdit.getInstance().getSessionManager().get(actor);
+        if (localSession == null || localSession.getSelectionWorld() == null)
+            throw new CommandException("Please select an area first. " +
+                    "Use WorldEdit to make a selection! " +
+                    "(see: https://worldedit.enginehub.org/en/latest/usage/regions/selections/).");
         try {
-            LocalSession localSession = WorldEdit.getInstance().getSessionManager().get(actor);
             return localSession.getRegionSelector(localSession.getSelectionWorld()).getRegion();
         } catch (IncompleteRegionException e) {
-            throw new CommandException(
-                    "Please select an area first. " +
-                            "Use WorldEdit to make a selection! " +
-                            "(see: https://worldedit.enginehub.org/en/latest/usage/regions/selections/).");
+            throw new CommandException("Please select an area first. " +
+                    "Use WorldEdit to make a selection! " +
+                    "(see: https://worldedit.enginehub.org/en/latest/usage/regions/selections/).");
         }
     }
 


### PR DESCRIPTION
I found the issue with the "null" output for invalid selections:

LocalSession.getRegionSelector(World) requires a non null world, but without any selection LocalSession.getSelectionWorld() returns a null world.

This should fix the wrong red "null" output for users who don't have a valid selection.