### PR TITLE
Add query methods to get values from MapFlags

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/ApplicableRegionSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/ApplicableRegionSet.java
@@ -144,6 +144,28 @@ public interface ApplicableRegionSet extends Iterable<ProtectedRegion> {
     <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key);
 
     /**
+     * Get the effective value for a key in a {@link MapFlag}. If there are multiple values
+     * (for example, if there are multiple regions with the same priority
+     * but with different farewell messages set, there would be multiple
+     * completing values), then the selected (or "winning") value will be undefined.
+     *
+     * <p>A subject can be provided that is used to determine whether the value
+     * of a flag on a particular region should be used. For example, if a
+     * flag's region group is set to {@link RegionGroup#MEMBERS} and the given
+     * subject is not a member, then the region would be skipped when
+     * querying that flag. If {@code null} is provided for the subject, then
+     * only flags that use {@link RegionGroup#ALL},
+     * {@link RegionGroup#NON_MEMBERS}, etc. will apply.</p>
+     *
+     * @param subject an optional subject, which would be used to determine the region group to apply
+     * @param flag the flag of type {@link MapFlag}
+     * @param key the key for the map flag
+     * @return a value, which could be {@code null}
+     */
+    @Nullable
+    <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key, @Nullable Flag<V> fallback);
+
+    /**
      * Get the effective values for a flag, returning a collection of all
      * values. It is up to the caller to determine which value, if any,
      * from the collection will be used.

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/ApplicableRegionSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/ApplicableRegionSet.java
@@ -23,6 +23,8 @@ import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.MapFlag;
+import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.managers.RegionManager;
@@ -118,6 +120,28 @@ public interface ApplicableRegionSet extends Iterable<ProtectedRegion> {
      */
     @Nullable
     <V> V queryValue(@Nullable RegionAssociable subject, Flag<V> flag);
+
+    /**
+     * Get the effective value for a key in a {@link MapFlag}. If there are multiple values
+     * (for example, if there are multiple regions with the same priority
+     * but with different farewell messages set, there would be multiple
+     * completing values), then the selected (or "winning") value will be undefined.
+     *
+     * <p>A subject can be provided that is used to determine whether the value
+     * of a flag on a particular region should be used. For example, if a
+     * flag's region group is set to {@link RegionGroup#MEMBERS} and the given
+     * subject is not a member, then the region would be skipped when
+     * querying that flag. If {@code null} is provided for the subject, then
+     * only flags that use {@link RegionGroup#ALL},
+     * {@link RegionGroup#NON_MEMBERS}, etc. will apply.</p>
+     *
+     * @param subject an optional subject, which would be used to determine the region group to apply
+     * @param flag the flag of type {@link MapFlag}
+     * @param key the key for the map flag
+     * @return a value, which could be {@code null}
+     */
+    @Nullable
+    <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key);
 
     /**
      * Get the effective values for a flag, returning a collection of all

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FailedLoadRegionSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FailedLoadRegionSet.java
@@ -70,8 +70,14 @@ public class FailedLoadRegionSet extends AbstractRegionSet {
     @Nullable
     @Override
     public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
+        return queryMapValue(subject, flag, key, null);
+    }
+
+    @Nullable
+    @Override
+    public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key, @Nullable Flag<V> fallback) {
         Map<K, V> defaultVal = flag.getDefault();
-        return defaultVal != null ? defaultVal.get(key) : null;
+        return defaultVal != null ? defaultVal.get(key) : fallback != null ? fallback.getDefault() : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FailedLoadRegionSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FailedLoadRegionSet.java
@@ -24,6 +24,7 @@ import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.MapFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
@@ -31,6 +32,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -63,6 +65,13 @@ public class FailedLoadRegionSet extends AbstractRegionSet {
             return (V) denyMessage;
         }
         return flag.getDefault();
+    }
+
+    @Nullable
+    @Override
+    public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
+        Map<K, V> defaultVal = flag.getDefault();
+        return defaultVal != null ? defaultVal.get(key) : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java
@@ -26,6 +26,7 @@ import com.sk89q.worldguard.domains.Association;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.MapFlag;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag.State;
@@ -222,6 +223,93 @@ public class FlagValueCalculator {
     public <V> V queryValue(@Nullable RegionAssociable subject, Flag<V> flag) {
         Collection<V> values = queryAllValues(subject, flag, true);
         return flag.chooseValue(values);
+    }
+
+    /**
+     * Get the effective value for a key in a {@link MapFlag}. If there are multiple values
+     * (for example, if there are multiple regions with the same priority
+     * but with different farewell messages set, there would be multiple
+     * completing values), then the selected (or "winning") value will be undefined.
+     *
+     * <p>A subject can be provided that is used to determine whether the value
+     * of a flag on a particular region should be used. For example, if a
+     * flag's region group is set to {@link RegionGroup#MEMBERS} and the given
+     * subject is not a member, then the region would be skipped when
+     * querying that flag. If {@code null} is provided for the subject, then
+     * only flags that use {@link RegionGroup#ALL},
+     * {@link RegionGroup#NON_MEMBERS}, etc. will apply.</p>
+     *
+     * @param subject an optional subject, which would be used to determine the region group to apply
+     * @param flag the flag of type {@link MapFlag}
+     * @param key the key for the map flag
+     * @return a value, which could be {@code null}
+     */
+    @Nullable
+    public <V, T> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<T, V> flag, T key) {
+        checkNotNull(flag);
+        checkNotNull(key);
+
+        V value = null;
+        int minimumPriority = Integer.MIN_VALUE;
+        Set<ProtectedRegion> ignoredParents = new HashSet<>();
+
+        for(ProtectedRegion region : getApplicable()) {
+            if (getPriority(region) < minimumPriority) {
+                break;
+            }
+
+            if (ignoredParents.contains(region)) {
+                continue;
+            }
+
+            V effectiveValue = getEffectiveMapValue(region, flag, key, subject);
+
+            if (effectiveValue != null) {
+                minimumPriority = getPriority(region);
+                value = effectiveValue;
+            }
+
+            addParents(ignoredParents, region);
+        }
+        return value;
+    }
+
+    @Nullable
+    private <V, T> V getEffectiveMapValue(ProtectedRegion region, MapFlag<T, V> mapFlag, T key, RegionAssociable subject) {
+        List<ProtectedRegion> seen = new ArrayList<>();
+        ProtectedRegion current = region;
+
+        while (current != null) {
+            seen.add(current);
+
+            Map<T, V> mapValue = current.getFlag(mapFlag);
+
+            if (mapValue != null && mapValue.containsKey(key)) {
+                boolean use = true;
+
+                if (mapFlag.getRegionGroupFlag() != null) {
+                    RegionGroup group = current.getFlag(mapFlag.getRegionGroupFlag());
+                    if (group == null) {
+                        group = mapFlag.getRegionGroupFlag().getDefault();
+                    }
+
+                    if (group == null) {
+                        use = false;
+                    } else if (subject == null) {
+                        use = group.contains(Association.NON_MEMBER);
+                    } else if (!group.contains(subject.getAssociation(seen))) {
+                        use = false;
+                    }
+                }
+
+                if (use) {
+                    return mapValue.get(key);
+                }
+            }
+
+            current = current.getParent();
+        }
+        return null;
     }
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java
@@ -268,7 +268,7 @@ public class FlagValueCalculator {
             if (effectiveValue != null) {
                 minimumPriority = getPriority(region);
                 consideredValues.put(region, effectiveValue);
-            } else {
+            } else if (fallback != null) {
                 effectiveValue = getEffectiveFlag(region, fallback, subject);
                 if (effectiveValue != null) {
                     minimumPriority = getPriority(region);
@@ -278,9 +278,17 @@ public class FlagValueCalculator {
 
             addParents(ignoredParents, region);
         }
-        V finalValue = flag.getValueFlag().chooseValue(consideredValues.values());
-        if (finalValue == null) return fallback.chooseValue(fallbackValues.values());
-        return finalValue;
+
+
+        if (consideredValues.isEmpty()) {
+            if (fallback != null && !fallbackValues.isEmpty()) {
+                return fallback.chooseValue(fallbackValues.values());
+            }
+            V defaultValue = flag.getValueFlag().getDefault();
+            return defaultValue != null ? defaultValue : fallback != null ? fallback.getDefault() : null;
+        }
+
+        return flag.getValueFlag().chooseValue(consideredValues.values());
     }
 
     @Nullable

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/PermissiveRegionSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/PermissiveRegionSet.java
@@ -64,8 +64,14 @@ public class PermissiveRegionSet extends AbstractRegionSet {
     @Nullable
     @Override
     public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
+        return queryMapValue(subject, flag, key, null);
+    }
+
+    @Nullable
+    @Override
+    public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key, @Nullable Flag<V> fallback) {
         Map<K, V> defaultVal = flag.getDefault();
-        return defaultVal != null ? defaultVal.get(key) : null;
+        return defaultVal != null ? defaultVal.get(key) : fallback != null ? fallback.getDefault() : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/PermissiveRegionSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/PermissiveRegionSet.java
@@ -24,6 +24,7 @@ import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.MapFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
@@ -31,6 +32,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -57,6 +59,13 @@ public class PermissiveRegionSet extends AbstractRegionSet {
             return (V) State.DENY;
         }
         return flag.getDefault();
+    }
+
+    @Nullable
+    @Override
+    public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
+        Map<K, V> defaultVal = flag.getDefault();
+        return defaultVal != null ? defaultVal.get(key) : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/RegionResultSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/RegionResultSet.java
@@ -22,6 +22,7 @@ package com.sk89q.worldguard.protection;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.MapFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
@@ -106,6 +107,12 @@ public class RegionResultSet extends AbstractRegionSet {
     @Override
     public <V> Collection<V> queryAllValues(@Nullable RegionAssociable subject, Flag<V> flag) {
         return flagValueCalculator.queryAllValues(subject, flag);
+    }
+
+    @Override
+    @Nullable
+    public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
+        return flagValueCalculator.queryMapValue(subject, flag, key);
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/RegionResultSet.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/RegionResultSet.java
@@ -112,7 +112,13 @@ public class RegionResultSet extends AbstractRegionSet {
     @Override
     @Nullable
     public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
-        return flagValueCalculator.queryMapValue(subject, flag, key);
+        return flagValueCalculator.queryMapValue(subject, flag, key, null);
+    }
+
+    @Override
+    @Nullable
+    public <V, K> V queryMapValue(@Nullable RegionAssociable subject, MapFlag<K, V> flag, K key, Flag<V> fallback) {
+        return flagValueCalculator.queryMapValue(subject, flag, key, fallback);
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/RegionQuery.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/RegionQuery.java
@@ -34,6 +34,8 @@ import com.sk89q.worldguard.protection.RegionResultSet;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.MapFlag;
+import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.managers.RegionManager;
@@ -317,6 +319,30 @@ public class RegionQuery {
     @Nullable
     public <V> V queryValue(Location location, @Nullable RegionAssociable associable, Flag<V> flag) {
         return getApplicableRegions(location).queryValue(associable, flag);
+    }
+
+    /**
+     * Get the effective value for a key in a {@link MapFlag}. If there are multiple values
+     * (for example, if there are multiple regions with the same priority
+     * but with different farewell messages set, there would be multiple
+     * completing values), then the selected (or "winning") value will be undefined.
+     *
+     * <p>A subject can be provided that is used to determine whether the value
+     * of a flag on a particular region should be used. For example, if a
+     * flag's region group is set to {@link RegionGroup#MEMBERS} and the given
+     * subject is not a member, then the region would be skipped when
+     * querying that flag. If {@code null} is provided for the subject, then
+     * only flags that use {@link RegionGroup#ALL},
+     * {@link RegionGroup#NON_MEMBERS}, etc. will apply.</p>
+     *
+     * @param subject an optional subject, which would be used to determine the region group to apply
+     * @param flag the flag of type {@link MapFlag}
+     * @param key the key for the map flag
+     * @return a value, which could be {@code null}
+     */
+    @Nullable
+    public <V, K> V queryMapValue(Location location, @Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
+        return getApplicableRegions(location).queryMapValue(subject, flag, key);
     }
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/RegionQuery.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/RegionQuery.java
@@ -174,6 +174,56 @@ public class RegionQuery {
     }
 
     /**
+     * Returns true if the BUILD flag allows the action in the location, but it
+     * can be overridden by a list of other flags. The BUILD flag will not
+     * override the other flags, but the other flags can override BUILD. If
+     * neither BUILD or any of the flags permit the action, then false will
+     * be returned.
+     *
+     * <p>Use this method when checking flags that are related to build
+     * protection. For example, lighting fire in a region should not be
+     * permitted unless the player is a member of the region or the
+     * LIGHTER flag allows it. However, the LIGHTER flag should be able
+     * to allow lighting fires even if BUILD is set to DENY.</p>
+     *
+     * <p>This method does include parameters for a {@link MapFlag}.</p>
+     *
+     * <p>How this method works (BUILD can be overridden by other flags but
+     * not the other way around) is inconsistent, but it's required for
+     * legacy reasons.</p>
+     *
+     * <p>This method does not check the region bypass permission. That must
+     * be done by the calling code.</p>
+     *
+     * @param location the location
+     * @param associable an optional associable
+     * @param mapFlag the MapFlag
+     * @param key the key for the MapFlag
+     * @param fallback the fallback flag for MapFlag
+     * @param flag the flags
+     * @return true if the result was {@code ALLOW}
+     * @see RegionResultSet#queryValue(RegionAssociable, Flag)
+     */
+    public <K> boolean testBuild(Location location, RegionAssociable associable, MapFlag<K, State> mapFlag, K key,
+                                 @Nullable StateFlag fallback, StateFlag... flag) {
+        if (mapFlag == null)
+            return testBuild(location, associable, flag);
+
+        if (flag.length == 0) {
+            return StateFlag.test(StateFlag.combine(
+                    StateFlag.denyToNone(queryState(location, associable, Flags.BUILD)),
+                    queryMapValue(location, associable, mapFlag, key, fallback)
+            ));
+        }
+
+        return StateFlag.test(StateFlag.combine(
+                StateFlag.denyToNone(queryState(location, associable, Flags.BUILD)),
+                queryMapValue(location, associable, mapFlag, key, fallback),
+                queryState(location, associable, flag)
+        ));
+    }
+
+    /**
      * Test whether the (effective) value for a list of state flags equals
      * {@code ALLOW}.
      *
@@ -343,6 +393,34 @@ public class RegionQuery {
     @Nullable
     public <V, K> V queryMapValue(Location location, @Nullable RegionAssociable subject, MapFlag<K, V> flag, K key) {
         return getApplicableRegions(location).queryMapValue(subject, flag, key);
+    }
+
+    /**
+     * Get the effective value for a key in a {@link MapFlag}. If there are multiple values
+     * (for example, if there are multiple regions with the same priority
+     * but with different farewell messages set, there would be multiple
+     * completing values), then the selected (or "winning") value will be undefined.
+     *
+     * <p>A subject can be provided that is used to determine whether the value
+     * of a flag on a particular region should be used. For example, if a
+     * flag's region group is set to {@link RegionGroup#MEMBERS} and the given
+     * subject is not a member, then the region would be skipped when
+     * querying that flag. If {@code null} is provided for the subject, then
+     * only flags that use {@link RegionGroup#ALL},
+     * {@link RegionGroup#NON_MEMBERS}, etc. will apply.</p>
+     *
+     * <p>It's possible to provide a fallback flag for the case when the key doesn't
+     * exist in the {@link MapFlag}.</p>
+     *
+     * @param subject an optional subject, which would be used to determine the region group to apply
+     * @param flag the flag of type {@link MapFlag}
+     * @param key the key for the map flag
+     * @param fallback the fallback flag
+     * @return a value, which could be {@code null}
+     */
+    @Nullable
+    public <V, K> V queryMapValue(Location location, @Nullable RegionAssociable subject, MapFlag<K, V> flag, K key, Flag<V> fallback) {
+        return getApplicableRegions(location).queryMapValue(subject, flag, key, fallback);
     }
 
     /**

--- a/worldguard-core/src/test/java/com/sk89q/worldguard/protection/FlagValueCalculatorMapFlagTest.java
+++ b/worldguard-core/src/test/java/com/sk89q/worldguard/protection/FlagValueCalculatorMapFlagTest.java
@@ -1,0 +1,124 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection;
+
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.MapFlag;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.StringFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@SuppressWarnings({"UnusedDeclaration"})
+public class FlagValueCalculatorMapFlagTest {
+    @Test
+    public void testGetEffectiveMapFlagWithFallback() throws Exception {
+        MockApplicableRegionSet mock = new MockApplicableRegionSet();
+
+        ProtectedRegion global = mock.global();
+        global.setFlag(Flags.BUILD, StateFlag.State.DENY);
+        MapFlag<String, StateFlag.State> mapFlag =
+                new MapFlag<>("test", new StringFlag(null), new StateFlag(null, true));
+        Map<String, StateFlag.State> map = new HashMap<>();
+        map.put("allow", StateFlag.State.ALLOW);
+        map.put("deny", StateFlag.State.DENY);
+        global.setFlag(mapFlag, map);
+
+        ApplicableRegionSet applicableSet = mock.getApplicableSet();
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "allow", Flags.BUILD),
+                equalTo(StateFlag.State.ALLOW));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "deny", Flags.BUILD),
+                equalTo(StateFlag.State.DENY));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "undefined", Flags.BUILD),
+                equalTo(StateFlag.State.DENY));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "allow", null),
+                equalTo(StateFlag.State.ALLOW));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "deny", null),
+                equalTo(StateFlag.State.DENY));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "undefined", null),
+                equalTo(StateFlag.State.ALLOW));
+    }
+
+    @Test
+    public void testGetEffectiveMapFlagWithSamePriority() throws Exception {
+        MockApplicableRegionSet mock = new MockApplicableRegionSet();
+
+        ProtectedRegion region1 = mock.add(0);
+        ProtectedRegion region2 = mock.add(0);
+
+        MapFlag<String, StateFlag.State> mapFlag =
+                new MapFlag<>("test", new StringFlag(null), new StateFlag(null, true));
+        Map<String, StateFlag.State> map1 = new HashMap<>();
+        Map<String, StateFlag.State> map2 = new HashMap<>();
+
+        map1.put("should-deny", StateFlag.State.ALLOW);
+        map2.put("should-deny", StateFlag.State.DENY);
+
+        map1.put("should-allow", StateFlag.State.ALLOW);
+
+        map1.put("should-allow2", StateFlag.State.ALLOW);
+        map2.put("should-allow2", StateFlag.State.ALLOW);
+
+        region1.setFlag(mapFlag, map1);
+        region2.setFlag(mapFlag, map2);
+
+        ApplicableRegionSet applicableSet = mock.getApplicableSet();
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "should-deny", null),
+                equalTo(StateFlag.State.DENY));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "should-allow", null),
+                equalTo(StateFlag.State.ALLOW));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "should-allow2", null),
+                equalTo(StateFlag.State.ALLOW));
+    }
+
+
+    @Test
+    public void testGetEffectiveMapFlagWithInheritance() throws Exception {
+        MockApplicableRegionSet mock = new MockApplicableRegionSet();
+
+        ProtectedRegion parent = mock.add(0);
+        ProtectedRegion child = mock.add(0, parent);
+
+        MapFlag<String, StateFlag.State> mapFlag =
+                new MapFlag<>("test", new StringFlag(null), new StateFlag(null, true));
+        Map<String, StateFlag.State> parentMap = new HashMap<>();
+        Map<String, StateFlag.State> childMap = new HashMap<>();
+
+        parentMap.put("useChildValue", StateFlag.State.ALLOW);
+        childMap.put("useChildValue", StateFlag.State.DENY);
+
+        parentMap.put("useParentValue", StateFlag.State.ALLOW);
+
+        parent.setFlag(mapFlag, parentMap);
+        child.setFlag(mapFlag, childMap);
+
+        ApplicableRegionSet applicableSet = mock.getApplicableSet();
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "useChildValue", null),
+                equalTo(StateFlag.State.DENY));
+        assertThat(applicableSet.queryMapValue(null, mapFlag, "useParentValue", null),
+                equalTo(StateFlag.State.ALLOW));
+    }
+}


### PR DESCRIPTION
I added some query methods to query value from MapFlags.
Usage:

- register the map flag (added in WorldGuard's Flags class):
```java
public static final MapFlag<ItemType, StateFlag.State> ITEM_PICKUP_TYPE =
            register(new MapFlag<>("item-material-pickup", new RegistryFlag<>(null, ItemType.REGISTRY), new StateFlag(null, true)));
```

- Use it in the code (changed RegionProtectionListener#onDestroyEntity for the test, just as test and should be cleaned up a little bit)
```java
        /* Item pickup */
        } else if (event.getEntity() instanceof Item) {
            ItemType itemType = BukkitAdapter.adapt(((Item)event.getEntity()).getItemStack()).getType();
            canDestroy = query.testBuild(BukkitAdapter.adapt(target), associable, Flags.ITEM_PICKUP_TYPE, itemType, Flags.ITEM_PICKUP, combine(event));
            what = "pick up items";

        /* Experience orb */
        } else if (event.getEntity() instanceof ExperienceOrb) {
```

- Compile and use the flags ingame

![grafik](https://user-images.githubusercontent.com/15250323/96165317-c0053600-0f1c-11eb-9b9f-50cb9a6c5c76.png)

The regions are overlapping. Flag `item-pickup` is set to deny, so nobody can pickup items by default. The flag `item-material-pickup` is set on two regions:
- You can pickup dirt and anvils but you can't pickup stone.

The implementation does work with region inheritance and region priorities. It does search for the matched key with the highest priority.