### PR TITLE
Add use-owner-association option

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -161,6 +161,7 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
         disableObsidianGenerators = getBoolean("protection.disable-obsidian-generators", false);
 
         useMaxPriorityAssociation = getBoolean("protection.use-max-priority-association", false);
+        useOwnerAssociation = getBoolean("protection.use-owner-association", false);
 
         blockPotions = new HashSet<>();
         for (String potionName : getStringList("gameplay.block-potions", null)) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
@@ -139,12 +139,13 @@ class AbstractListener implements Listener {
                 loc = entity.getLocation();
             }
             return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc),
-                    config.useMaxPriorityAssociation);
+                    config.useMaxPriorityAssociation, config.useOwnerAssociation);
         } else if (rootCause instanceof Block) {
             RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
             Location loc = ((Block) rootCause).getLocation();
             return new DelayedRegionOverlapAssociation(query, BukkitAdapter.adapt(loc),
-                    getWorldConfig(BukkitAdapter.adapt(loc.getWorld())).useMaxPriorityAssociation);
+                    getWorldConfig(BukkitAdapter.adapt(loc.getWorld())).useMaxPriorityAssociation,
+                    getWorldConfig(BukkitAdapter.adapt(loc.getWorld())).useOwnerAssociation);
         } else {
             return Associables.constant(Association.NON_MEMBER);
         }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -174,6 +174,7 @@ public abstract class WorldConfiguration {
     public boolean ignoreHopperMoveEvents;
     public boolean breakDeniedHoppers;
     public boolean useMaxPriorityAssociation;
+    public boolean useOwnerAssociation;
     protected Map<String, Integer> maxRegionCounts;
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/DelayedRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/DelayedRegionOverlapAssociation.java
@@ -41,7 +41,7 @@ public class DelayedRegionOverlapAssociation extends com.sk89q.worldguard.protec
      * @param location the location
      */
     public DelayedRegionOverlapAssociation(RegionQuery query, Location location) {
-        super(query, location, false);
+        super(query, location, false, false);
     }
 
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
@@ -22,9 +22,13 @@ package com.sk89q.worldguard.protection.association;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldguard.domains.Association;
+import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,23 +37,97 @@ public abstract class AbstractRegionOverlapAssociation implements RegionAssociab
     @Nullable
     protected Set<ProtectedRegion> source;
     private boolean useMaxPriorityAssociation;
+    private boolean useOwnerAssociation;
     private int maxPriority;
+    private Set<ProtectedRegion> maxPriorityRegions;
 
-    protected AbstractRegionOverlapAssociation(@Nullable Set<ProtectedRegion> source, boolean useMaxPriorityAssociation) {
+    protected AbstractRegionOverlapAssociation(@Nullable Set<ProtectedRegion> source, boolean useMaxPriorityAssociation, boolean useOwnerAssociation) {
         this.source = source;
         this.useMaxPriorityAssociation = useMaxPriorityAssociation;
+        this.useOwnerAssociation = useOwnerAssociation;
     }
 
     protected void calcMaxPriority() {
         checkNotNull(source);
         int best = 0;
+        Set<ProtectedRegion> bestRegions = new HashSet<>();
         for (ProtectedRegion region : source) {
             int priority = region.getPriority();
             if (priority > best) {
                 best = priority;
+                bestRegions.clear();
+                bestRegions.add(region);
+            } else if (priority == best) {
+                bestRegions.add(region);
             }
         }
         this.maxPriority = best;
+        this.maxPriorityRegions = bestRegions;
+    }
+
+    private boolean hasAnyRegionAnyOwner(Collection<? extends ProtectedRegion> regions, DefaultDomain owners) {
+        for (ProtectedRegion region : regions) {
+            if (!Collections.disjoint(region.getOwners().getUniqueIds(), owners.getUniqueIds())) {
+                return true;
+            }
+
+            if (!Collections.disjoint(region.getOwners().getPlayers(), owners.getPlayers())) {
+                return true;
+            }
+
+            // Assuming players of different groups are disjoint and groups are not empty.
+            if (!Collections.disjoint(region.getOwners().getGroups(), owners.getGroups())) {
+                return true;
+            }
+
+            // A complete check would require the following code.
+            // However, this is clearly not possible.
+            /*for (String ownerGroup : owners.getGroups()) {
+                if (isEmptyGroup(ownerGroup)) {
+                    continue;
+                }
+
+                if (region.getOwners().getGroups().contains(ownerGroup)) {
+                    return true;
+                }
+
+                for (String regionGroup : region.getOwners().getGroups()) {
+                    if (!areDisjointGroups(regionGroup, ownerGroup)) {
+                        return true;
+                    }
+                }
+            }*/
+
+            // Check if the group domains contain players from the player domains.
+            // This would require either to convert from player uniqueId/name to LocalPlayer
+            // or implementations of the GroupDomain#contains(UUID/String) methods.
+            // Both can be implemented in the future via WorldGuardPlatform for example.
+            /*for (UUID uniqueId : owners.getUniqueIds()) {
+                if (region.getOwners().getGroupDomain().contains(uniqueId)) {
+                    return true;
+                }
+            }
+
+            for (String player : owners.getPlayers()) {
+                if (region.getOwners().getGroupDomain().contains(player)) {
+                    return true;
+                }
+            }
+
+            for (UUID uniqueId : region.getOwners().getUniqueIds()) {
+                if (owners.getGroupDomain().contains(uniqueId)) {
+                    return true;
+                }
+            }
+
+            for (String player : region.getOwners().getPlayers()) {
+                if (owners.getGroupDomain().contains(player)) {
+                    return true;
+                }
+            }*/
+        }
+
+        return false;
     }
 
     @Override
@@ -67,6 +145,20 @@ public abstract class AbstractRegionOverlapAssociation implements RegionAssociab
                         return Association.OWNER;
                     }
                 } else {
+                    return Association.OWNER;
+                }
+            }
+
+            if (useOwnerAssociation) {
+                Set<ProtectedRegion> source;
+
+                if (useMaxPriorityAssociation) {
+                    source = maxPriorityRegions;
+                } else {
+                    source = this.source;
+                }
+
+                if (hasAnyRegionAnyOwner(source, region.getOwners())) {
                     return Association.OWNER;
                 }
             }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/DelayedRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/DelayedRegionOverlapAssociation.java
@@ -47,7 +47,7 @@ public class DelayedRegionOverlapAssociation extends AbstractRegionOverlapAssoci
      * @param location the location
      */
     public DelayedRegionOverlapAssociation(RegionQuery query, Location location) {
-        this(query, location, false);
+        this(query, location, false, false);
     }
 
     /**
@@ -55,9 +55,10 @@ public class DelayedRegionOverlapAssociation extends AbstractRegionOverlapAssoci
      * @param query the query
      * @param location the location
      * @param useMaxPriorityAssociation whether to use the max priority from regions to determine association
+     * @param useOwnerAssociation whether to use the owners from regions to determine association
      */
-    public DelayedRegionOverlapAssociation(RegionQuery query, Location location, boolean useMaxPriorityAssociation) {
-        super(null, useMaxPriorityAssociation);
+    public DelayedRegionOverlapAssociation(RegionQuery query, Location location, boolean useMaxPriorityAssociation, boolean useOwnerAssociation) {
+        super(null, useMaxPriorityAssociation, useOwnerAssociation);
         checkNotNull(query);
         checkNotNull(location);
         this.query = query;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/RegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/RegionOverlapAssociation.java
@@ -36,7 +36,7 @@ public class RegionOverlapAssociation extends AbstractRegionOverlapAssociation {
      * @param source set of regions that input regions must be contained within
      */
     public RegionOverlapAssociation(@Nonnull Set<ProtectedRegion> source) {
-        this(source, false);
+        this(source, false, false);
     }
 
     /**
@@ -44,9 +44,10 @@ public class RegionOverlapAssociation extends AbstractRegionOverlapAssociation {
      *
      * @param source set of regions that input regions must be contained within
      * @param useMaxPriorityAssociation whether to use the max priority from regions to determine association
+     * @param useOwnerAssociation whether to use the owners from regions to determine association
      */
-    public RegionOverlapAssociation(@Nonnull Set<ProtectedRegion> source, boolean useMaxPriorityAssociation) {
-        super(source, useMaxPriorityAssociation);
+    public RegionOverlapAssociation(@Nonnull Set<ProtectedRegion> source, boolean useMaxPriorityAssociation, boolean useOwnerAssociation) {
+        super(source, useMaxPriorityAssociation, useOwnerAssociation);
         calcMaxPriority();
     }
 

--- a/worldguard-core/src/test/java/com/sk89q/worldguard/protection/RegionOverlapTest.java
+++ b/worldguard-core/src/test/java/com/sk89q/worldguard/protection/RegionOverlapTest.java
@@ -200,7 +200,7 @@ public abstract class RegionOverlapTest {
 
         HashSet<ProtectedRegion> source = new HashSet<>();
         source.add(courtyard);
-        RegionOverlapAssociation assoc = new RegionOverlapAssociation(source, useMaxPriorityAssociation);
+        RegionOverlapAssociation assoc = new RegionOverlapAssociation(source, useMaxPriorityAssociation, false);
 
         // Outside
         appl = manager.getApplicableRegions(outside);
@@ -220,7 +220,7 @@ public abstract class RegionOverlapTest {
         HashSet<ProtectedRegion> source = new HashSet<>();
         source.add(fountain);
         source.add(courtyard);
-        RegionOverlapAssociation assoc = new RegionOverlapAssociation(source, useMaxPriorityAssociation);
+        RegionOverlapAssociation assoc = new RegionOverlapAssociation(source, useMaxPriorityAssociation, false);
 
         // Outside
         appl = manager.getApplicableRegions(outside);
@@ -238,7 +238,7 @@ public abstract class RegionOverlapTest {
         ApplicableRegionSet appl;
 
         HashSet<ProtectedRegion> source = new HashSet<>();
-        RegionOverlapAssociation assoc = new RegionOverlapAssociation(source, useMaxPriorityAssociation);
+        RegionOverlapAssociation assoc = new RegionOverlapAssociation(source, useMaxPriorityAssociation, false);
 
         // Outside
         appl = manager.getApplicableRegions(outside);


### PR DESCRIPTION
This PR adds the option `use-owner-association` to the world configuration. I will explain this feature in the following example. Suppose you have a protected "plots" area in which plots are created for players. See picture below.

![2020-10-27_20 35 02_edited](https://user-images.githubusercontent.com/18699205/97354635-fd12e600-1895-11eb-9a98-ba9f51b84d84.png)

Players can now modify the surroundings (the protected "plots" area) by using pistons, fluids, ..., although they shouldn't be able to do this. If a player (Alice) owns two plots next to each other, it breaks pistons, fluids, ... between the plots. The plots are protected from outside though. See picture below.

![2020-10-27_20 32 10](https://user-images.githubusercontent.com/18699205/97355217-e1f4a600-1896-11eb-97ca-4e7670627230.png)

The first issue can be fixed by setting `use-max-priority-association` to `true`. See picture below.

![2020-10-27_20 33 03](https://user-images.githubusercontent.com/18699205/97355428-2ed87c80-1897-11eb-8538-813c738aae40.png)

And the `use-owner-association` option can be used to get the desired behavior. See picture below.

![2020-10-27_20 33 39](https://user-images.githubusercontent.com/18699205/97355547-562f4980-1897-11eb-9972-0347438de689.png)

I'd appreciate this feature. However, if you think this shouldn't be in WorldGuard, feel free to close it. I can easily maintain my own fork for this and I won't be upset. Thanks in advance.