### PR TITLE
Catch Throwables instead of Exceptions while (un)marshalling flags

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/FlagUtil.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/FlagUtil.java
@@ -48,7 +48,7 @@ public final class FlagUtil {
         for (Entry<Flag<?>, Object> entry : values.entrySet()) {
             try {
                 rawValues.put(entry.getKey().getName(), marshal(entry.getKey(), entry.getValue()));
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 log.log(Level.WARNING, "Failed to marshal flag value for " + entry.getKey() + "; value is " + entry.getValue(), e);
             }
         }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/registry/SimpleFlagRegistry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/registry/SimpleFlagRegistry.java
@@ -144,7 +144,7 @@ public class SimpleFlagRegistry implements FlagRegistry {
                     } else {
                         log.warning("Failed to parse flag '" + flag.getName() + "' with value '" + entry.getValue() + "'");
                     }
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     log.log(Level.WARNING, "Failed to unmarshal flag value for " + flag, e);
                 }
             }


### PR DESCRIPTION
I updated a plugin from me. I used some external stuff to serialize data in flags.
My plugin generated a NoSuchMethodError which doesn't extend Exception. With that exception WorldGuard doesn't start.