### PR TITLE
Added arguments to /rg toggle-bypass: on, off

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Sets;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandException;
-import com.sk89q.minecraft.util.commands.CommandPermissions;
 import com.sk89q.minecraft.util.commands.CommandPermissionsException;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.command.util.AsyncCommandBuilder;
@@ -1124,6 +1123,7 @@ public final class RegionCommands extends RegionCommandsBase {
     }
 
     @Command(aliases = {"toggle-bypass", "bypass"},
+             usage = "[on|off]",
              desc = "Toggle region bypassing, effectively ignoring bypass permissions.")
     public void toggleBypass(CommandContext args, Actor sender) throws CommandException {
         LocalPlayer player = worldGuard.checkPlayer(sender);
@@ -1131,7 +1131,17 @@ public final class RegionCommands extends RegionCommandsBase {
             throw new CommandPermissionsException();
         }
         Session session = WorldGuard.getInstance().getPlatform().getSessionManager().get(player);
-        if (session.hasBypassDisabled()) {
+        boolean shouldEnableBypass;
+        if (args.argsLength() > 0) {
+            String arg1 = args.getString(0);
+            if (!arg1.equalsIgnoreCase("on") && !arg1.equalsIgnoreCase("off")) {
+                throw new CommandException("Allowed optional arguments are: on, off");
+            }
+            shouldEnableBypass = arg1.equalsIgnoreCase("on");
+        } else {
+            shouldEnableBypass = session.hasBypassDisabled();
+        }
+        if (shouldEnableBypass) {
             session.setBypassDisabled(false);
             player.print("You are now bypassing region protection (as long as you have permission).");
         } else {


### PR DESCRIPTION
With these optional arguments (/rg bypass [on|off])  you can have better control wether enabling or disabling bypass mode.
This is always useful when you (or a script) does'nt really know the current bypass state of the player. 