### PR TITLE
Move the Mob Blocker feature from CraftBook to WorldGuard

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -218,6 +218,7 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
         blockGroundSlimes = getBoolean("mobs.block-above-ground-slimes", false);
         blockOtherExplosions = getBoolean("mobs.block-other-explosions", false);
         blockZombieDoorDestruction = getBoolean("mobs.block-zombie-door-destruction", false);
+        blockEntityVehicleEntry = getBoolean("mobs.block-vehicle-entry", false);
 
         disableFallDamage = getBoolean("player-damage.disable-fall-damage", false);
         disableLavaDamage = getBoolean("player-damage.disable-lava-damage", false);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -851,7 +851,7 @@ public class WorldGuardEntityListener implements Listener {
         ConfigurationManager cfg = WorldGuard.getInstance().getPlatform().getGlobalStateManager();
         WorldConfiguration wcfg = cfg.get(BukkitAdapter.adapt(event.getEntered().getWorld()));
 
-        if(wcfg.blockEntityVehicleEntry && !(event.getEntered() instanceof Player)) {
+        if (wcfg.blockEntityVehicleEntry && !(event.getEntered() instanceof Player)) {
             event.setCancelled(true);
         }
     }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -82,6 +82,7 @@ import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.entity.PigZapEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.projectiles.ProjectileSource;
@@ -842,6 +843,16 @@ public class WorldGuardEntityListener implements Listener {
                 event.setCancelled(true);
                 return;
             }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onVehicleEnter(VehicleEnterEvent event) {
+        ConfigurationManager cfg = WorldGuard.getInstance().getPlatform().getGlobalStateManager();
+        WorldConfiguration wcfg = cfg.get(BukkitAdapter.adapt(event.getEntered().getWorld()));
+
+        if(wcfg.blockEntityVehicleEntry && !(event.getEntered() instanceof Player)) {
+            event.setCancelled(true);
         }
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -105,6 +105,7 @@ public abstract class WorldConfiguration {
     public boolean blockEntityPaintingDestroy;
     public boolean blockEntityItemFrameDestroy;
     public boolean blockEntityArmorStandDestroy;
+    public boolean blockEntityVehicleEntry;
     public boolean blockPluginSpawning;
     public boolean blockGroundSlimes;
     public boolean blockZombieDoorDestruction;


### PR DESCRIPTION
This feature makes no sense within CraftBook, so I've made this PR to move it to WorldGuard.

Basically, it disables the MC functionality of letting mobs being able to enter vehicles. Ideally, it'd just block collision entry, but that isn't reliably possible with the Bukkit API.