### PR TITLE
Display CommandException if WorldEdit failed to initialize

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -385,6 +385,8 @@ public class WorldGuardPlugin extends JavaPlugin {
         Plugin worldEdit = getServer().getPluginManager().getPlugin("WorldEdit");
         if (worldEdit == null) {
             throw new CommandException("WorldEdit does not appear to be installed.");
+        } else if (!worldEdit.isEnabled()) {
+            throw new CommandException("WorldEdit does not appear to be enabled.");
         }
 
         if (worldEdit instanceof WorldEditPlugin) {


### PR DESCRIPTION
This checks if WorldEdit is enabled, and resolves the NoClassDefFoundError that would normally show if WorldEdit failed to initialize.

An example of the error that this fixes can be seen here: https://pastebin.com/vy2gWj0w