### PR TITLE
Remove unnecessary FlagValueCalculator#getPriority(ProtectedRegion) calls

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java
@@ -113,11 +113,13 @@ public class FlagValueCalculator {
         Set<ProtectedRegion> ignoredRegions = Sets.newHashSet();
 
         for (ProtectedRegion region : getApplicable()) {
+            int priority = getPriority(region);
+
             // Don't consider lower priorities below minimumPriority
             // (which starts at Integer.MIN_VALUE). A region that "counts"
             // (has the flag set OR has members) will raise minimumPriority
             // to its own priority.
-            if (getPriority(region) < minimumPriority) {
+            if (priority < minimumPriority) {
                 break;
             }
 
@@ -130,7 +132,7 @@ public class FlagValueCalculator {
                 continue;
             }
 
-            minimumPriority = getPriority(region);
+            minimumPriority = priority;
 
             boolean member = RegionGroup.MEMBERS.contains(subject.getAssociation(Collections.singletonList(region)));
 
@@ -255,7 +257,9 @@ public class FlagValueCalculator {
         Set<ProtectedRegion> ignoredParents = new HashSet<>();
 
         for(ProtectedRegion region : getApplicable()) {
-            if (getPriority(region) < minimumPriority) {
+            int priority = getPriority(region);
+
+            if (priority < minimumPriority) {
                 break;
             }
 
@@ -266,12 +270,12 @@ public class FlagValueCalculator {
             V effectiveValue = getEffectiveMapValue(region, flag, key, subject);
 
             if (effectiveValue != null) {
-                minimumPriority = getPriority(region);
+                minimumPriority = priority;
                 consideredValues.put(region, effectiveValue);
             } else if (fallback != null) {
                 effectiveValue = getEffectiveFlag(region, fallback, subject);
                 if (effectiveValue != null) {
-                    minimumPriority = getPriority(region);
+                    minimumPriority = priority;
                     fallbackValues.put(region, effectiveValue);
                 }
             }
@@ -388,7 +392,9 @@ public class FlagValueCalculator {
         Set<ProtectedRegion> ignoredParents = new HashSet<>();
 
         for (ProtectedRegion region : getApplicable()) {
-            if (getPriority(region) < minimumPriority) {
+            int priority = getPriority(region);
+
+            if (priority < minimumPriority) {
                 break;
             }
 
@@ -397,7 +403,6 @@ public class FlagValueCalculator {
             }
 
             V value = getEffectiveFlag(region, flag, subject);
-            int priority = getPriority(region);
 
             if (value != null) {
                 minimumPriority = priority;
@@ -415,7 +420,7 @@ public class FlagValueCalculator {
             // PASSTHROUGH is not set to ALLOW
             if (priority != minimumPriority && flag.implicitlySetWithMembership()
                     && getEffectiveFlag(region, Flags.PASSTHROUGH, subject) != State.ALLOW) {
-                minimumPriority = getPriority(region);
+                minimumPriority = priority;
             }
         }
 


### PR DESCRIPTION
Yeah, that's micro-optimization, however, it's good practice to create a variable and avoid repeated method calls.