### PR TITLE
Add nonplayer-protection-domains flag

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -46,6 +46,7 @@ public final class Flags {
 
     // Overrides membership check
     public static final StateFlag PASSTHROUGH = register(new StateFlag("passthrough", false));
+    public static final SetFlag<String> NONPLAYER_PROTECTION_DOMAINS = register(new SetFlag<>("nonplayer-protection-domains", new StringFlag(null)));
 
     // This flag is unlike the others. It forces the checking of region membership
     public static final StateFlag BUILD = register(new BuildFlag("build", true));


### PR DESCRIPTION
This PR is a generalization of #1661. The feature to remove boundaries for non player associables between regions can now be achieved by setting the `region-unions` flags of these regions (instead of ownership checks). The `region-unions` flag is a `Set<String>` flag, containing the names of the region unions in which the region is a member of. If a non player associable is a member of the region r1, then it is also member of the region r2, if there is at least one region union in which both regions are member of.