### PR TITLE
Small performance improvement for `PlayerDomain#contains()`

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/PlayerDomain.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/PlayerDomain.java
@@ -149,7 +149,7 @@ public class PlayerDomain implements Domain, ChangeTracked {
     @Override
     public boolean contains(LocalPlayer player) {
         checkNotNull(player);
-        return contains(player.getName().trim().toLowerCase()) || contains(player.getUniqueId());
+        return contains(player.getUniqueId()) || contains(player.getName().trim().toLowerCase());
     }
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/PlayerDomain.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/PlayerDomain.java
@@ -149,7 +149,7 @@ public class PlayerDomain implements Domain, ChangeTracked {
     @Override
     public boolean contains(LocalPlayer player) {
         checkNotNull(player);
-        return contains(player.getUniqueId()) || contains(player.getName().trim().toLowerCase());
+        return contains(player.getUniqueId()) || (!names.isEmpty() && contains(player.getName()));
     }
 
     /**


### PR DESCRIPTION
Hi, we have recently received a profiler report which indicated a small bottleneck in the `PlayerDomain` code.
Note that this does not seem to affect `GroupDomain` and `DefaultDomain`, I checked :)

## The bottleneck
We received the following spark report from a user: https://spark.lucko.me/dQ7B1zMjk5?hl=13018
You may need to scroll down a bit, it is marked in red though.

The bottleneck we found was able to be identified as `PlayerDomain#contains()`.

![image](https://user-images.githubusercontent.com/3967898/117827760-8eb1d600-b271-11eb-81bb-32f72aeba2ea.png)

## Proposed solution
Since this particular issue involved our own code as well, we are already taking actions via caching on our side.
But we came to the conclusion that there may be an improvement to be made here as well and wanted to share it with you.
Since `CraftOfflinePlayer#getName()` sometimes triggers an I/O operation to read the player data from NBT ([source](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java#49-70)), the `#getName()` operation is more expensive than `#getUniqueId()`.
Therefore, we think swapping the order of this condition might improve performance, even if it's just a small improvement which may not be noticeable on most servers.

What are your thoughts on this? :)

<hr />
 
cc: @md5sha256 @WalshyDev