### PR TITLE
Remove unused RegionGroup.MEMBERS from the teleport flag

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -134,7 +134,7 @@ public final class Flags {
     public static final SetFlag<String> ALLOWED_CMDS = register(new SetFlag<>("allowed-cmds", new CommandStringFlag(null)));
 
     // locations
-    public static final LocationFlag TELE_LOC = register(new LocationFlag("teleport", RegionGroup.MEMBERS));
+    public static final LocationFlag TELE_LOC = register(new LocationFlag("teleport"));
     public static final LocationFlag SPAWN_LOC = register(new LocationFlag("spawn", RegionGroup.MEMBERS));
 
     /**


### PR DESCRIPTION
Since the teleport region group flag isn't used, there is no reason to use a special region group flag.

See EngineHub/WorldGuardDocs#19