### PR TITLE
Reduce CPU/allocs from Bukkit event listeners

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitConfigurationManager.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitConfigurationManager.java
@@ -93,7 +93,14 @@ public class BukkitConfigurationManager extends YamlConfigurationManager {
      */
     @Override
     public BukkitWorldConfiguration get(World world) {
-        String worldName = world.getName();
+        return this.get(world.getName());
+    }
+
+    public BukkitWorldConfiguration get(org.bukkit.World world) {
+        return this.get(world.getName());
+    }
+
+    private BukkitWorldConfiguration get(String worldName) {
         BukkitWorldConfiguration config = worlds.get(worldName);
         BukkitWorldConfiguration newConfig = null;
 
@@ -101,8 +108,8 @@ public class BukkitConfigurationManager extends YamlConfigurationManager {
             if (newConfig == null) {
                 newConfig = new BukkitWorldConfiguration(plugin, worldName, this.getConfig());
             }
-            worlds.putIfAbsent(world.getName(), newConfig);
-            config = worlds.get(world.getName());
+            worlds.putIfAbsent(worldName, newConfig);
+            config = worlds.get(worldName);
         }
 
         return config;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
@@ -21,6 +21,7 @@ package com.sk89q.worldguard.bukkit.listener;
 
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.BukkitConfigurationManager;
 import com.sk89q.worldguard.bukkit.BukkitWorldConfiguration;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.bukkit.util.Materials;
@@ -93,7 +94,7 @@ public class WorldGuardBlockListener implements Listener {
      * @return The configuration for {@code world}
      */
     private WorldConfiguration getWorldConfig(World world) {
-        return WorldGuard.getInstance().getPlatform().getGlobalStateManager().get(BukkitAdapter.adapt(world));
+        return ((BukkitConfigurationManager) WorldGuard.getInstance().getPlatform().getGlobalStateManager()).get(world);
     }
 
     /**


### PR DESCRIPTION
Currently the system allocates and initializes a WorldEdit World instance in nearly every Bukkit event listener. This change bypasses the adapting and instead uses the Bukkit world, while still not exposing how internally the Bukkit world configuration is stored.

Here you can see the impact on CPU (collected with an async profiler to avoid the Java safepoint problem):

![image](https://user-images.githubusercontent.com/3516420/120862367-71111d00-c54e-11eb-8676-4195ad7591f9.png)

While admittedly the CPU usage is low (albeit on a 100 player server with a lowish amount of redstone) the impact on allocations is much higher:

![image](https://user-images.githubusercontent.com/3516420/120862488-a9186000-c54e-11eb-941b-5528d4bc6854.png)

From just the physics event, 20% of my server's allocations are adapting the world to look up the config. The result of this PR on my live server was GCs became roughly 20% less frequent, as well as a small increase in TPS.
