### PR TITLE
Fix Iron Doors

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -753,8 +753,11 @@ public final class Materials {
         }
 
         // Generated via tag
-        for (Material door : Tag.DOORS.getValues()) {
-            MATERIAL_FLAGS.put(door, MODIFIED_ON_RIGHT);
+        for (Material woodenDoor : Tag.WOODEN_DOORS.getValues()) {
+            MATERIAL_FLAGS.put(woodenDoor, MODIFIED_ON_RIGHT);
+        }
+        for (Material woodenTrapdoor : Tag.WOODEN_TRAPDOORS.getValues()) {
+            MATERIAL_FLAGS.put(woodenTrapdoor, MODIFIED_ON_RIGHT);
         }
         for (Material boat : Tag.ITEMS_BOATS.getValues()) {
             MATERIAL_FLAGS.put(boat, 0);
@@ -1321,7 +1324,7 @@ public final class Materials {
      */
     public static boolean isUseFlagApplicable(Material material) {
         if (Tag.BUTTONS.isTagged(material)
-                || Tag.DOORS.isTagged(material)
+                || Tag.WOODEN_DOORS.isTagged(material)
                 || Tag.WOODEN_TRAPDOORS.isTagged(material)
                 || Tag.FENCE_GATES.isTagged(material)
                 || Tag.PRESSURE_PLATES.isTagged(material)) {


### PR DESCRIPTION
Iron Doors were already correctly handled above. The `Tag.DOORS` loop overwrites this correct behavior. Instead `Tag.WOODEN_DOORS` should be used. I have also fixed the wrong usage of `Tag.DOORS` in the function `isUseFlagApplicable`.

There is no issue with Trapdoors. However, I have added a `Tag.WOODEN_TRAPDOORS` loop as well, to be more consistent.

