### PR TITLE
Add member inheritance for non-player associables

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
@@ -87,31 +87,35 @@ public abstract class AbstractRegionOverlapAssociation implements RegionAssociab
     public Association getAssociation(List<ProtectedRegion> regions) {
         checkNotNull(source);
         for (ProtectedRegion region : regions) {
-            if ((region.getId().equals(ProtectedRegion.GLOBAL_REGION) && source.isEmpty())) {
-                return Association.OWNER;
-            }
-
-            if (source.contains(region)) {
-                if (useMaxPriorityAssociation) {
-                    int priority = region.getPriority();
-                    if (priority == maxPriority) {
-                        return Association.OWNER;
-                    }
-                } else {
+            while (region != null) {
+                if ((region.getId().equals(ProtectedRegion.GLOBAL_REGION) && source.isEmpty())) {
                     return Association.OWNER;
                 }
-            }
 
-            Set<ProtectedRegion> source;
+                if (source.contains(region)) {
+                    if (useMaxPriorityAssociation) {
+                        int priority = region.getPriority();
+                        if (priority == maxPriority) {
+                            return Association.OWNER;
+                        }
+                    } else {
+                        return Association.OWNER;
+                    }
+                }
 
-            if (useMaxPriorityAssociation) {
-                source = maxPriorityRegions;
-            } else {
-                source = this.source;
-            }
+                Set<ProtectedRegion> source;
 
-            if (checkNonplayerProtectionDomains(source, region.getFlag(Flags.NONPLAYER_PROTECTION_DOMAINS))) {
-                return Association.OWNER;
+                if (useMaxPriorityAssociation) {
+                    source = maxPriorityRegions;
+                } else {
+                    source = this.source;
+                }
+
+                if (checkNonplayerProtectionDomains(source, region.getFlag(Flags.NONPLAYER_PROTECTION_DOMAINS))) {
+                    return Association.OWNER;
+                }
+
+                region = region.getParent();
             }
         }
 

--- a/worldguard-core/src/test/java/com/sk89q/worldguard/protection/RegionOverlapTest.java
+++ b/worldguard-core/src/test/java/com/sk89q/worldguard/protection/RegionOverlapTest.java
@@ -210,7 +210,7 @@ public abstract class RegionOverlapTest {
         assertTrue(appl.testState(assoc, Flags.BUILD));
         // Inside fountain
         appl = manager.getApplicableRegions(inFountain);
-        assertFalse(appl.testState(assoc, Flags.BUILD));
+        assertTrue(appl.testState(assoc, Flags.BUILD));
     }
 
     @Test


### PR DESCRIPTION
There are a few reasons why I think this should be added:

1. As I have already described in EngineHub/WorldGuardDocs#24 non-player associables are also members of the parent regions. This essentially means that parent regions "inherit" members from child regions but not the other (if at all, expected) way around, as this is the case for player associables.
2. [FlagValueCalculator#getEffectiveFlag(ProtectedRegion, Flag<V>, RegionAssociable)](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java#L470) implements a part of member inheritance by [collecting already seen (child) regions to pass](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-core/src/main/java/com/sk89q/worldguard/protection/FlagValueCalculator.java#L512) them to [RegionAssociable#getAssociation(List<ProtectedRegion>)](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/RegionAssociable.java#L38). Of course this applies to player and non-player associables. This "partial" implementetion is even more confusing and unintuitive for the behavior in the case of non-player associables.
3. The other part of member inheritance for player associables is the [LocalPlayer#getAssociation(List<ProtectedRegion>)](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-core/src/main/java/com/sk89q/worldguard/LocalPlayer.java#L57) method, which internally also checks the parent regions of the passed regions via [ProtectedRegion#isOwner(LocalPlayer)](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java#L282) for example, unlike the [AbstractRegionOverlapAssociation#getAssociation(List<ProtectedRegion>)](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java#L87) method, which completely ignores the parent regions of the passed regions. Essentially this PR applies the same logic from player associables to non-player associables.