### PR TITLE
Fix handlers order when registering one with after.

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
@@ -128,7 +128,7 @@ public abstract class AbstractSessionManager implements SessionManager {
             int index = handlers.indexOf(wrappedAfter != null ? wrappedAfter : after);
             if (index == -1) return false;
 
-            handlers.add(index, factory); // shifts "after" right one, and everything after "after" right one
+            handlers.add(index + 1, factory); // shifts "after" right one, and everything after "after" right one
         }
         wrappedHandlers.put(factory, wrappedFactory);
         return true;


### PR DESCRIPTION
I am not sure exactly if this is the source of the problem, but when i tried registering my handlers using ExitFlag.FACTORY as "after" like how the javadocs said it, it seemed that my handler was running before the ExitFlag handler which means mine will run even if ExitFlag returns false. I used null as after and it worked then. Maybe i understand the "after" incorrectly but in my mind my customHandler should run after the "after" not the other way around if that makes sense. Let me know if I didn't undertstand it correctly.
Sorry for my english!