### PR TITLE
Block Other Explosion for Block-Like Entities

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -197,7 +197,7 @@ public class WorldGuardEntityListener implements Listener {
             // handled anywhere else
             if (type == DamageCause.BLOCK_EXPLOSION
                     && (wcfg.blockOtherExplosions
-                            || (wcfg.explosionFlagCancellation
+                            || ((wcfg.explosionFlagCancellation || Entities.isConsideredBuildingIfUsed(defender))
                                 && !StateFlag.test(WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery()
                     .queryState(BukkitAdapter.adapt(defender.getLocation()), (RegionAssociable) null, Flags.OTHER_EXPLOSION))))) {
                 event.setCancelled(true);


### PR DESCRIPTION
This will bring OTHER_EXPLOSION flag handling for block like entities in line with how OTHER_EXPLOSION is used for block damage protection.