### PR TITLE
Add Pointed Dripstone to Vine-Flag

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -1412,6 +1412,7 @@ public final class Materials {
                 newType == Material.KELP ||
                 newType == Material.TWISTING_VINES ||
                 newType == Material.WEEPING_VINES ||
+                newType == Material.POINTED_DRIPSTONE ||
                 Tag.CAVE_VINES.isTagged(newType);
 
     }


### PR DESCRIPTION
Added Pointed Driptstone to Vine-Flag, so pointed Dripstone will not expand anymore, if vine-growth is set to DENY.