### PR TITLE
Protection flags for lecterns

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -262,10 +262,15 @@ public class RegionProtectionListener extends AbstractListener {
                 canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.CHEST_ACCESS));
                 what = "open that";
 
-            /* Inventory for blocks with the possibility to be only use, e.g. lectern */
-            } else if (handleAsInventoryUsage(event.getOriginalEvent())) {
-                canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.CHEST_ACCESS));
+            /* Take from lectern */
+            } else if (event.getOriginalEvent() instanceof PlayerTakeLecternBookEvent) {
+                canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.INTERACT, Flags.LECTERN_ACCESS, Flags.LECTERN_TAKE));
                 what = "take that";
+
+            /* Read book on lectern */
+            } else if (type == Material.LECTERN) {
+                canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.INTERACT, Flags.LECTERN_ACCESS));
+                what = "use that";
 
             /* Anvils */
             } else if (Materials.isAnvil(type)) {
@@ -558,16 +563,6 @@ public class RegionProtectionListener extends AbstractListener {
             flags[flag.length + i] = extra.get(i);
         }
         return flags;
-    }
-
-    /**
-     * Check if that event should be handled as inventory usage, e.g. if a player takes a book from a lectern
-     *
-     * @param event the event to handle
-     * @return whether it should be handled as inventory usage
-     */
-    private static boolean handleAsInventoryUsage(Event event) {
-        return event instanceof PlayerTakeLecternBookEvent;
     }
 
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -58,6 +58,8 @@ public final class Flags {
     public static final StateFlag BLOCK_PLACE = register(new StateFlag("block-place", false));
     public static final StateFlag USE = register(new StateFlag("use", false));
     public static final StateFlag INTERACT = register(new StateFlag("interact", false));
+    public static final StateFlag LECTERN_ACCESS = register(new StateFlag("lectern-access", false));
+    public static final StateFlag LECTERN_TAKE = register(new StateFlag("lectern-take", false));
     public static final StateFlag DAMAGE_ANIMALS = register(new StateFlag("damage-animals", false));
     public static final StateFlag PVP = register(new StateFlag("pvp", false));
     public static final StateFlag SLEEP = register(new StateFlag("sleep", false));


### PR DESCRIPTION
How to configure use/interact/chest-access to allow for players to read books on lecterns without being able to take them seem to be a topic that pops up every now and then. Current solution seem to revolve around using multiple nested regions if you want people to access chests, but not be able to take books from lecterns.

My solution was to move lectern access to separate flags from chest access, thus eliminating the need for multiple nested regions.
