### PR TITLE
Allows claimed regions to inherit from a template region

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -281,7 +281,7 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
         regionWand = convertLegacyItem(getString("regions.wand", ItemTypes.LEATHER.getId()));
         maxClaimVolume = getInt("regions.max-claim-volume", 30000);
         claimOnlyInsideExistingRegions = getBoolean("regions.claim-only-inside-existing-regions", false);
-        templateWhenClaiming = getString("regions.template-when-claiming", "");
+        setParentOnClaim = getString("regions.set-parent-on-claim", "");
         boundedLocationFlags = getBoolean("regions.location-flags-only-inside-regions", false);
 
         maxRegionCountPerPlayer = getInt("regions.max-region-count-per-player.default", 7);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -281,6 +281,7 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
         regionWand = convertLegacyItem(getString("regions.wand", ItemTypes.LEATHER.getId()));
         maxClaimVolume = getInt("regions.max-claim-volume", 30000);
         claimOnlyInsideExistingRegions = getBoolean("regions.claim-only-inside-existing-regions", false);
+        templateWhenClaiming = getString("regions.template-when-claiming", "");
         boundedLocationFlags = getBoolean("regions.location-flags-only-inside-regions", false);
 
         maxRegionCountPerPlayer = getInt("regions.max-region-count-per-player.default", 7);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -315,8 +315,8 @@ public final class RegionCommands extends RegionCommandsBase {
         }
 
         // Inherit from a template region
-        if (wcfg.templateWhenClaiming != "") {
-            ProtectedRegion templateRegion = manager.getRegion(wcfg.templateWhenClaiming);
+        if (wcfg.setParentOnClaim != "")  {
+            ProtectedRegion templateRegion = manager.getRegion(wcfg.setParentOnClaim);
             if (templateRegion != null) {
                 try {
                     region.setParent(templateRegion);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -281,7 +281,7 @@ public final class RegionCommands extends RegionCommandsBase {
             }
         }
 
-        // We have to check whether this region violates the space of any other reion
+        // We have to check whether this region violates the space of any other region
         ApplicableRegionSet regions = manager.getApplicableRegions(region);
 
         // Check if this region overlaps any other region
@@ -311,6 +311,18 @@ public final class RegionCommands extends RegionCommandsBase {
                 player.printError("This region is too large to claim.");
                 player.printError("Max. volume: " + wcfg.maxClaimVolume + ", your volume: " + region.volume());
                 return;
+            }
+        }
+
+        // Inherit from a template region
+        if (wcfg.templateWhenClaiming != "") {
+            ProtectedRegion templateRegion = manager.getRegion(wcfg.templateWhenClaiming);
+            if (templateRegion != null) {
+                try {
+                    region.setParent(templateRegion);
+                } catch (CircularInheritanceException e) {
+                    throw new CommandException(e.getMessage());
+                }
             }
         }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -21,6 +21,7 @@ package com.sk89q.worldguard.commands.region;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
@@ -315,7 +316,7 @@ public final class RegionCommands extends RegionCommandsBase {
         }
 
         // Inherit from a template region
-        if (wcfg.setParentOnClaim != "")  {
+        if (!Strings.isNullOrEmpty(wcfg.setParentOnClaim)) {
             ProtectedRegion templateRegion = manager.getRegion(wcfg.setParentOnClaim);
             if (templateRegion != null) {
                 try {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -129,6 +129,7 @@ public abstract class WorldConfiguration {
     public boolean allowTamedSpawns;
     public int maxClaimVolume;
     public boolean claimOnlyInsideExistingRegions;
+    public String templateWhenClaiming;
     public int maxRegionCountPerPlayer;
     public boolean antiWolfDumbness;
     public boolean signChestProtection;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -129,7 +129,7 @@ public abstract class WorldConfiguration {
     public boolean allowTamedSpawns;
     public int maxClaimVolume;
     public boolean claimOnlyInsideExistingRegions;
-    public String templateWhenClaiming;
+    public String setParentOnClaim;
     public int maxRegionCountPerPlayer;
     public boolean antiWolfDumbness;
     public boolean signChestProtection;


### PR DESCRIPTION
Hi,

With this PR I intend to cover a functionality that I have always missed when creating servers where the community could claim their own regions.

The idea is to add support to define template regions per world from which all the claimed regions will inherit by default, allowing to unify their properties automatically without having to modify them manually.

An example use case would be to disable the lava flow in all claimed regions for obvious reasons. I know it would be possible to achieve this by disabling lava flow in the `__global__` region, but it would not be desirable to have lava stops flowing around the world.

## Configuration

Set the following parameter in the `regions` section of `config.yml` with the name of the template region.

``` yml
template-when-claiming: 'template_region'
```

Add the template region in the `regions.yml` file of the desired world(s).

``` yml
template_region:
    members: {}
    flags: {lava-flow: deny, fire-spread: deny}
    owners: {}
    type: global
    priority: 0
```

## Scenarios

A new claimed region will be created inheriting from the template region if:
- The parameter `template-when-claiming` has been set in the plugin configuration and the corresponding template region has been created in the same world as the claimed region.

A new claimed region will be created as before if:
- The `template-when-claiming` parameter has not been defined or is an empty string
- A template region has been set according to the `template-when-claiming` parameter but not in the world of the claimed region.

I'm not sure if this functionality has value for the plugin, but it certainly does for me as I explained before. 

Regards.