### PR TITLE
Optimize Region List and Region Teleport commands

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -30,6 +30,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.command.util.AsyncCommandBuilder;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.component.ErrorFormat;
 import com.sk89q.worldedit.util.formatting.component.LabelFormat;
@@ -41,6 +42,7 @@ import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
 import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.commands.task.RegionAdder;
@@ -74,6 +76,7 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion.CircularInheritanceException;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.util.DomainInputResolver.UserLocatorPolicy;
+import com.sk89q.worldguard.protection.util.WorldEditRegionConverter;
 import com.sk89q.worldguard.session.Session;
 import com.sk89q.worldguard.util.Enums;
 import com.sk89q.worldguard.util.logging.LoggerToChatHandler;
@@ -436,9 +439,9 @@ public final class RegionCommands extends RegionCommandsBase {
      * @throws CommandException any error
      */
     @Command(aliases = {"list"},
-             usage = "[page]",
+             usage = "[-w world] [-p owner [-n]] [-s] [-i filter] [page]",
              desc = "Get a list of regions",
-             flags = "np:w:",
+             flags = "np:w:i:s",
              max = 1)
     public void list(CommandContext args, Actor sender) throws CommandException {
         warnAboutSaveFailures(sender);
@@ -473,6 +476,16 @@ public final class RegionCommands extends RegionCommandsBase {
         task.setPage(page);
         if (ownedBy != null) {
             task.filterOwnedByName(ownedBy, args.hasFlag('n'));
+        }
+
+        if (args.hasFlag('s')) {
+            ProtectedRegion existing = checkRegionFromSelection(sender, "tmp");
+            task.filterByIntersecting(existing);
+        }
+
+        // -i string is in region id
+        if (args.hasFlag('i')) {
+            task.filterIdByMatch(args.getFlag('i'));
         }
 
         AsyncCommandBuilder.wrap(task, sender)
@@ -1133,8 +1146,8 @@ public final class RegionCommands extends RegionCommandsBase {
      * @throws CommandException any error
      */
     @Command(aliases = {"teleport", "tp"},
-             usage = "<id>",
-             flags = "sw:",
+             usage = "[-w world] [-c|s] <id>",
+             flags = "csw:",
              desc = "Teleports you to the location associated with the region.",
              min = 1, max = 1)
     public void teleport(CommandContext args, Actor sender) throws CommandException {
@@ -1158,6 +1171,23 @@ public final class RegionCommands extends RegionCommandsBase {
             if (teleportLocation == null) {
                 throw new CommandException(
                         "The region has no spawn point associated.");
+            }
+        } else if (args.hasFlag('c')) {
+            // Check permissions
+            if (!getPermissionModel(player).mayTeleportToCenter(existing)) {
+                throw new CommandPermissionsException();
+            }
+            Region region = WorldEditRegionConverter.convertToRegion(existing);
+            if (region == null || region.getCenter() == null) {
+                throw new CommandException("The region has no center point.");
+            }
+            if (player.getGameMode() == GameModes.SPECTATOR) {
+                teleportLocation = new Location(world, region.getCenter(), 0, 0);
+            } else {
+                // TODO: Add some method to create a safe teleport location.
+                // The method AbstractPlayerActor$findFreePoisition(Location loc) is no good way for this.
+                // It doesn't return the found location and it can't be checked if the location is inside the region.
+                throw new CommandException("Center teleport is only availible in Spectator gamemode.");
             }
         } else {
             teleportLocation = FlagValueCalculator.getEffectiveFlagOf(existing, Flags.TELE_LOC, player);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionPrintoutBuilder.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionPrintoutBuilder.java
@@ -327,6 +327,12 @@ public class RegionPrintoutBuilder implements Callable<TextComponent> {
                                             + teleFlag.getBlockZ()))))
                     .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND,
                             "/rg tp -w \"" + world + "\" " + region.getId()))));
+        } else if (perms != null && perms.mayTeleportToCenter(region) && region.isPhysicalArea()) {
+            builder.append(TextComponent.space().append(TextComponent.of("[Center Teleport]", TextColor.GRAY)
+                    .hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT,
+                            TextComponent.of("Click to teleport to the center of the region")))
+                    .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND,
+                            "/rg tp -c -w \"" + world + "\" " + region.getId()))));
         }
 
         newline();

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/task/RegionLister.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/task/RegionLister.java
@@ -158,7 +158,7 @@ public class RegionLister implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         Map<String, ProtectedRegion> regions = manager.getRegions();
-        Collection<ProtectedRegion> iterableRegions = manager.getRegions().values();
+        Collection<ProtectedRegion> iterableRegions = regions.values();
 
         if (filterByIntersecting != null) {
             iterableRegions = filterByIntersecting.getIntersectingRegions(iterableRegions);
@@ -184,7 +184,7 @@ public class RegionLister implements Callable<Integer> {
         // insert global on top
         if (regions.containsKey("__global__")) {
             final RegionListEntry entry = new RegionListEntry(regions.get("__global__"));
-            if (entry.matches(ownerMatcher)) {
+            if (entry.matches(idFilter) && entry.matches(ownerMatcher)) {
                 entries.add(0, entry);
             }
         }
@@ -198,6 +198,8 @@ public class RegionLister implements Callable<Integer> {
         String cmd = "/rg list -w \"" + world + "\""
                 + (playerName != null ? " -p " + playerName : "")
                 + (nameOnly ? " -n" : "")
+                + (filterByIntersecting != null ? " -s" : "")
+                + (idFilter != null ? " -i " + idFilter : "")
                 + " %page%";
         PaginationBox box = new RegionListBox(title, cmd, perms, entries, world);
         sender.print(box.create(page));

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/internal/permission/RegionPermissionModel.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/internal/permission/RegionPermissionModel.java
@@ -110,6 +110,10 @@ public class RegionPermissionModel extends AbstractPermissionModel {
         return hasPatternPermission("teleport", region);
     }
 
+    public boolean mayTeleportToCenter(ProtectedRegion region) {
+        return hasPatternPermission("teleportcenter", region);
+    }
+
     public boolean mayOverrideLocationFlagBounds(ProtectedRegion region) {
         return hasPatternPermission("locationoverride", region);
     }
@@ -129,7 +133,7 @@ public class RegionPermissionModel extends AbstractPermissionModel {
             return mayList();
         }
     }
-    
+
     public boolean maySetFlag(ProtectedRegion region) {
         return hasPatternPermission("flag.regions", region);
     }
@@ -199,5 +203,4 @@ public class RegionPermissionModel extends AbstractPermissionModel {
 
         return hasPluginPermission(effectivePerm);
     }
-
 }


### PR DESCRIPTION
After I was unable to fix git for https://github.com/EngineHub/WorldGuard/pull/1621 this is the new PR.
I removed the regex pattern matching as I don't see a good way to implement it. Storing the pattern doesn't work that fine and it's enough to have a flag to filter for region ids containing a string.

The changes are pretty straight forward and should improve the user experience.

Optimized command usage for /rg list and /rg teleport:
* added a flag to the teleport command to teleport the actor to the center of the region
* added a flag to the list command to filter the regions for special ids
* ~~added a flag to the list command to change the filter variant to regex~~
* added a flag to the list command to get regions intersecting your selection