### PR TITLE
Update V1__Initial.sql

### DIFF
--- a/worldguard-bukkit/src/main/resources/migrations/region/mysql/V1__Initial.sql
+++ b/worldguard-bukkit/src/main/resources/migrations/region/mysql/V1__Initial.sql
@@ -87,7 +87,7 @@ CREATE  TABLE IF NOT EXISTS `${tablePrefix}region_flag` (
   `region_id` VARCHAR(128) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
   `world_id` INT(10) UNSIGNED NOT NULL ,
   `flag` VARCHAR(45) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
-  `value` VARCHAR(512) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
+  `value` VARCHAR(1024) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
   PRIMARY KEY (`id`) ,
   INDEX `fk_flags_region` (`region_id` ASC, `world_id` ASC) ,
   CONSTRAINT `fk_${tablePrefix}flags_region`


### PR DESCRIPTION
Prevent database error on save when using all available region flags. Size 512 is not enough for all flags.

`[13:23:28 INFO]: Lasergott issued server command: /land buy
[13:23:28 WARN]: com.sk89q.worldguard.protection.managers.storage.StorageException: Failed to save the region data to the database
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.storage.sql.SQLRegionDatabase.saveChanges(SQLRegionDatabase.java:270)
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.RegionManager.saveChanges(RegionManager.java:134)
[13:23:28 WARN]:        at cubit.jar//de.linzn.cubit.internal.cubitRegion.region.SaveRegions.saveData(SaveRegions.java:34)
[13:23:28 WARN]:        at cubit.jar//de.linzn.cubit.internal.cubitRegion.region.SaveRegions.save(SaveRegions.java:21)
[13:23:28 WARN]:        at cubit.jar//de.linzn.cubit.internal.cubitRegion.CubitRegionManager.worldRegion(CubitRegionManager.java:108)
[13:23:28 WARN]:        at cubit.jar//de.linzn.cubit.internal.cubitRegion.CubitRegionManager.createRegion(CubitRegionManager.java:78)
[13:23:28 WARN]:        at cubit.jar//de.linzn.cubit.bukkit.command.land.main.BuyLand.runCmd(BuyLand.java:88)
[13:23:28 WARN]:        at cubit.jar//de.linzn.cubit.bukkit.command.land.CommandLand.lambda$onCommand$0(CommandLand.java:61)
[13:23:28 WARN]:        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
[13:23:28 WARN]:        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[13:23:28 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[13:23:28 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[13:23:28 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
[13:23:28 WARN]: Caused by: java.sql.BatchUpdateException: Data truncation: Data too long for column 'value' at row 1
[13:23:28 WARN]:        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[13:23:28 WARN]:        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
[13:23:28 WARN]:        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[13:23:28 WARN]:        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
[13:23:28 WARN]:        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
[13:23:28 WARN]:        at com.mysql.cj.util.Util.handleNewInstance(Util.java:192)
[13:23:28 WARN]:        at com.mysql.cj.util.Util.getInstance(Util.java:167)
[13:23:28 WARN]:        at com.mysql.cj.util.Util.getInstance(Util.java:174)
[13:23:28 WARN]:        at com.mysql.cj.jdbc.exceptions.SQLError.createBatchUpdateException(SQLError.java:224)
[13:23:28 WARN]:        at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchSerially(ClientPreparedStatement.java:853)
[13:23:28 WARN]:        at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchInternal(ClientPreparedStatement.java:435)
[13:23:28 WARN]:        at com.mysql.cj.jdbc.StatementImpl.executeBatch(StatementImpl.java:800)
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.storage.sql.StatementBatch.executeRemaining(StatementBatch.java:50)
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.storage.sql.RegionUpdater.replaceFlags(RegionUpdater.java:170)
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.storage.sql.RegionUpdater.apply(RegionUpdater.java:331)
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.storage.sql.DataUpdater.executeSave(DataUpdater.java:130)
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.storage.sql.DataUpdater.saveChanges(DataUpdater.java:73)
[13:23:28 WARN]:        at worldguard-bukkit-7.0.7-SNAPSHOT-dist.jar//com.sk89q.worldguard.protection.managers.storage.sql.SQLRegionDatabase.saveChanges(SQLRegionDatabase.java:268)
[13:23:28 WARN]:        ... 12 more
[13:23:28 WARN]: Caused by: com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'value' at row 1
[13:23:28 WARN]:        at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:104)
[13:23:28 WARN]:        at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)
[13:23:28 WARN]:        at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1098)
[13:23:28 WARN]:        at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchSerially(ClientPreparedStatement.java:832)
[13:23:28 WARN]:        ... 20 more
[13:23:28 WARN]: [Cubit] An internal error occurred during: [CREATE-REGION]`