### PR TITLE
Append OnlineMode server information to ServerReport

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/report/ServerReport.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/report/ServerReport.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldguard.bukkit.util.report;
 
 import com.sk89q.worldedit.util.report.DataReport;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 
@@ -33,8 +34,17 @@ public class ServerReport extends DataReport {
         append("Bukkit Version", server.getBukkitVersion());
         append("Implementation", server.getName() + " " + server.getVersion());
         append("Player Count", "%d/%d", Bukkit.getOnlinePlayers().size(), server.getMaxPlayers());
-
         append("Server Class Source", server.getClass().getProtectionDomain().getCodeSource().getLocation());
+
+        DataReport onlineMode = new DataReport("Online Mode");
+        onlineMode.append("enabled?", server.getOnlineMode());
+        if (PaperLib.isSpigot()) {
+            onlineMode.append("BungeeCord support?", Bukkit.spigot().getSpigotConfig().getBoolean("settings.bungeecord", false));
+        }
+        if (PaperLib.isPaper()) {
+            onlineMode.append("Velocity support?", Bukkit.spigot().getPaperConfig().getBoolean("settings.velocity-support.enabled", false));
+        }
+        append(onlineMode.getTitle(), onlineMode);
 
         DataReport spawning = new DataReport("Spawning");
         spawning.append("Ambient Spawn Limit", server.getAmbientSpawnLimit());


### PR DESCRIPTION
This will add informations to the current online mode configuration from a server.

Enabled BungeeCord and Velocity support will be displayed too as there are may servers with disabled online mode but a proxy for uuid resolution.

Server report with enabled online mode:
```
Bukkit Version: 1.18.2-R0.1-SNAPSHOT
Implementation: Paper git-Paper-225 (MC: 1.18.2)
Player Count: 0/20
Online Mode: 
  enabled?: true
  BungeeCord support?: false
  Velocity support?: false
...
```

Server report with disabled online mode but enabled velocity support:
```
Bukkit Version: 1.18.2-R0.1-SNAPSHOT
Implementation: TerraPaper git-TerraPaper-12aa150 (MC: 1.18.2)
Player Count: 0/100
Online Mode:
  enabled: false
  BungeeCord support?: false
  Velocity support?: true
...
```