### PR TITLE
Remove lowercase conversion

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
     const val AUTO_VALUE = "1.9"
     const val JUNIT = "5.8.1"
     const val MOCKITO = "4.3.1"
-    const val SQUIRRELID = "0.3.0"
+    const val SQUIRRELID = "0.4.0"
     const val GUAVA = "31.0.1-jre"
     const val FINDBUGS = "3.0.2"
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/blacklist/BlacklistEntry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/blacklist/BlacklistEntry.java
@@ -67,7 +67,7 @@ public class BlacklistEntry {
     public void setIgnoreGroups(String[] ignoreGroups) {
         Set<String> ignoreGroupsSet = new HashSet<>();
         for (String group : ignoreGroups) {
-            ignoreGroupsSet.add(group.toLowerCase());
+            ignoreGroupsSet.add(group);
         }
         this.ignoreGroups = ignoreGroupsSet;
     }
@@ -122,7 +122,7 @@ public class BlacklistEntry {
 
         if (ignoreGroups != null) {
             for (String group : player.getGroups()) {
-                if (ignoreGroups.contains(group.toLowerCase())) {
+                if (ignoreGroups.contains(group)) {
                     return true;
                 }
             }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/GroupDomain.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/GroupDomain.java
@@ -74,7 +74,7 @@ public class GroupDomain implements Domain, ChangeTracked {
         checkNotNull(name);
         if (!name.trim().isEmpty()) {
             setDirty(true);
-            groups.add(name.trim().toLowerCase());
+            groups.add(name.trim());
         }
     }
 
@@ -86,7 +86,7 @@ public class GroupDomain implements Domain, ChangeTracked {
     public void removeGroup(String name) {
         checkNotNull(name);
         setDirty(true);
-        groups.remove(name.trim().toLowerCase());
+        groups.remove(name.trim());
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/domains/PlayerDomain.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/domains/PlayerDomain.java
@@ -80,7 +80,7 @@ public class PlayerDomain implements Domain, ChangeTracked {
         checkNotNull(name);
         if (!name.trim().isEmpty()) {
             setDirty(true);
-            names.add(name.trim().toLowerCase());
+            names.add(name.trim());
             // Trim because some names contain spaces (previously valid Minecraft
             // names) and we cannot store these correctly in the SQL storage
             // implementations
@@ -119,7 +119,7 @@ public class PlayerDomain implements Domain, ChangeTracked {
     public void removePlayer(String name) {
         checkNotNull(name);
         setDirty(true);
-        names.remove(name.trim().toLowerCase());
+        names.remove(name.trim());
     }
 
     /**
@@ -181,7 +181,7 @@ public class PlayerDomain implements Domain, ChangeTracked {
     @Override
     public boolean contains(String playerName) {
         checkNotNull(playerName);
-        return names.contains(playerName.trim().toLowerCase());
+        return names.contains(playerName.trim());
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/migration/UUIDMigration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/migration/UUIDMigration.java
@@ -118,7 +118,7 @@ public class UUIDMigration extends AbstractMigration {
                 profileService.findAllByName(lookupNames, new Predicate<Profile>() {
                     @Override
                     public boolean apply(Profile profile) {
-                        resolvedNames.put(profile.getName().toLowerCase(), profile.getUniqueId());
+                        resolvedNames.put(profile.getName(), profile.getUniqueId());
                         return true;
                     }
                 });
@@ -199,7 +199,7 @@ public class UUIDMigration extends AbstractMigration {
         }
 
         for (String name : domain.getPlayers()) {
-            UUID uuid = resolvedNames.get(name.toLowerCase());
+            UUID uuid = resolvedNames.get(name);
             if (uuid != null) {
                 playerDomain.addPlayer(uuid);
             } else {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/RegionUpdater.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/RegionUpdater.java
@@ -95,7 +95,7 @@ class RegionUpdater {
         }
 
         for (String name : domain.getGroups()) {
-            groupNames.add(name.toLowerCase());
+            groupNames.add(name);
         }
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/RegionUpdater.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/RegionUpdater.java
@@ -87,7 +87,7 @@ class RegionUpdater {
     private void addDomain(DefaultDomain domain) {
         //noinspection deprecation
         for (String name : domain.getPlayers()) {
-            userNames.add(name.toLowerCase());
+            userNames.add(name);
         }
 
         for (UUID uuid : domain.getUniqueIds()) {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/TableCache.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/TableCache.java
@@ -255,7 +255,7 @@ abstract class TableCache<V> {
 
         @Override
         protected String toKey(String object) {
-            return object.toLowerCase();
+            return object;
         }
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/TableCache.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/TableCache.java
@@ -207,7 +207,7 @@ abstract class TableCache<V> {
 
         @Override
         protected String toKey(String object) {
-            return object.toLowerCase();
+            return object;
         }
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/util/DomainInputResolver.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/util/DomainInputResolver.java
@@ -109,11 +109,11 @@ public class DomainInputResolver implements Callable<DefaultDomain> {
                             domain.addPlayer(s);
                             break;
                         case UUID_ONLY:
-                            namesToQuery.add(s.toLowerCase());
+                            namesToQuery.add(s);
                             break;
                         case UUID_AND_NAME:
                             domain.addPlayer(s);
-                            namesToQuery.add(s.toLowerCase());
+                            namesToQuery.add(s);
                     }
                 }
             }
@@ -122,7 +122,7 @@ public class DomainInputResolver implements Callable<DefaultDomain> {
         if (!namesToQuery.isEmpty()) {
             try {
                 for (Profile profile : profileService.findAllByName(namesToQuery)) {
-                    namesToQuery.remove(profile.getName().toLowerCase());
+                    namesToQuery.remove(profile.getName());
                     domain.addPlayer(profile.getUniqueId());
                 }
             } catch (IOException e) {

--- a/worldguard-core/src/test/java/com/sk89q/worldguard/TestPlayer.java
+++ b/worldguard-core/src/test/java/com/sk89q/worldguard/TestPlayer.java
@@ -50,7 +50,7 @@ public class TestPlayer extends AbstractPlayerActor implements LocalPlayer {
     }
 
     public void addGroup(String group) {
-        groups.add(group.toLowerCase());
+        groups.add(group);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class TestPlayer extends AbstractPlayerActor implements LocalPlayer {
 
     @Override
     public boolean hasGroup(String group) {
-        return groups.contains(group.toLowerCase());
+        return groups.contains(group);
     }
 
     @Override


### PR DESCRIPTION
See [related PR](https://github.com/EngineHub/SquirrelID/pull/16) for SquirrelID, which must be merged before this one.

I've also removed the conversion for groups, just for the sake of consistency, and won't mind if you'll consider it unwanted. There are also some other `toLowerCase()` calls, e.g. for hostKeys, which I didn't touch, let me know if they should be removed too.