### PR TITLE
entity-armor-stand-destroy flag is added.

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -66,20 +66,7 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Dispenser;
-import org.bukkit.entity.AreaEffectCloud;
-import org.bukkit.entity.Creeper;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.FallingBlock;
-import org.bukkit.entity.Firework;
-import org.bukkit.entity.Item;
-import org.bukkit.entity.ItemFrame;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Painting;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Tameable;
-import org.bukkit.entity.ThrownPotion;
+import org.bukkit.entity.*;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -762,6 +749,8 @@ public class EventAbstractionListener extends AbstractListener {
                 destroyEntityEvent.getRelevantFlags().add(Flags.ENTITY_ITEM_FRAME_DESTROY);
             } else if (event.getEntity() instanceof Painting) {
                 destroyEntityEvent.getRelevantFlags().add(Flags.ENTITY_PAINTING_DESTROY);
+            } else if (event.getEntity() instanceof ArmorStand) {
+                destroyEntityEvent.getRelevantFlags().add(Flags.ENTITY_ARMOR_STAND_DESTROY);
             }
             Events.fireToCancel(event, destroyEntityEvent);
         }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -208,8 +208,8 @@ public class WorldGuardEntityListener extends AbstractListener {
                 event.setCancelled(true);
                 return;
             }
-        } else if (defender instanceof ArmorStand && !(attacker instanceof Player)) {
-            if (wcfg.blockEntityArmorStandDestroy) {
+        } else if (defender instanceof ArmorStand) {
+            if (checkArmorStandProtection(attacker, (ArmorStand) defender)) {
                 event.setCancelled(true);
                 return;
             }
@@ -334,9 +334,10 @@ public class WorldGuardEntityListener extends AbstractListener {
                 event.setCancelled(true);
                 return;
             }
-        } else if (defender instanceof ArmorStand && Entities.isNonPlayerCreature(attacker)) {
-            if (wcfg.blockEntityArmorStandDestroy) {
+        } else if (defender instanceof ArmorStand) {
+            if (checkArmorStandProtection(attacker, (ArmorStand) defender)) {
                 event.setCancelled(true);
+                return;
             }
         }
 
@@ -851,4 +852,27 @@ public class WorldGuardEntityListener extends AbstractListener {
         return false;
     }
 
+    /**
+     * Checks regions and config settings to protect items from being knocked
+     * out of armor stand.
+     * @param attacker attacking entity
+     * @param defender armor stand being damaged
+     * @return true if the event should be cancelled
+     */
+    private boolean checkArmorStandProtection(Entity attacker, ArmorStand defender) {
+        World world = defender.getWorld();
+        WorldConfiguration wcfg = getWorldConfig(world);
+        if (wcfg.useRegions) {
+            // bukkit throws this event when a player attempts to remove an item from a frame
+            if (!(attacker instanceof Player)) {
+                if (!StateFlag.test(WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().queryState(BukkitAdapter.adapt(defender.getLocation()), (RegionAssociable) null, Flags.ENTITY_ARMOR_STAND_DESTROY))) {
+                    return true;
+                }
+            }
+        }
+        if (wcfg.blockEntityArmorStandDestroy && !(attacker instanceof Player)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardHangingListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardHangingListener.java
@@ -27,14 +27,7 @@ import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import org.bukkit.World;
-import org.bukkit.entity.Creeper;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Hanging;
-import org.bukkit.entity.ItemFrame;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Painting;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
@@ -89,6 +82,11 @@ public class WorldGuardHangingListener extends AbstractListener {
                         && (wcfg.blockEntityItemFrameDestroy
                         || (wcfg.useRegions
                         && !StateFlag.test(WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().queryState(BukkitAdapter.adapt(hanging.getLocation()), (RegionAssociable) null, Flags.ENTITY_ITEM_FRAME_DESTROY))))) {
+                    event.setCancelled(true);
+                } else if (hanging instanceof ArmorStand
+                        && (wcfg.blockEntityArmorStandDestroy
+                        || (wcfg.useRegions
+                        && !StateFlag.test(WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().queryState(BukkitAdapter.adapt(hanging.getLocation()), (RegionAssociable) null, Flags.ENTITY_ARMOR_STAND_DESTROY))))) {
                     event.setCancelled(true);
                 }
             }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -99,6 +99,7 @@ public final class Flags {
     public static final StateFlag RAVAGER_RAVAGE = register(new StateFlag("ravager-grief", true));
     public static final StateFlag ENTITY_PAINTING_DESTROY = register(new StateFlag("entity-painting-destroy", true));
     public static final StateFlag ENTITY_ITEM_FRAME_DESTROY = register(new StateFlag("entity-item-frame-destroy", true));
+    public static final StateFlag ENTITY_ARMOR_STAND_DESTROY = register(new StateFlag("entity-armor-stand-destroy", true));
 
     // mob spawning related
     public static final StateFlag MOB_SPAWNING = register(new StateFlag("mob-spawning", true));


### PR DESCRIPTION
entity-armor-stand-destroy flag can be changed by a player so that the player can protect armer stand again explosion.
Evidence: https://youtu.be/xHLtpaDZ3po