### PR TITLE
Account for possible world nullability in Entity#getOrigin Location

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/AbstractListener.java
@@ -135,7 +135,8 @@ class AbstractListener implements Listener {
             Location loc;
             if (PaperLib.isPaper()  && config.usePaperEntityOrigin) {
                 loc = entity.getOrigin();
-                if (loc == null) {
+                // Origin world may be null, and thus a Location with a null world created, which cannot be adapted to a WorldEdit location
+                if (loc == null || loc.getWorld() == null) {
                     loc = entity.getLocation();
                 }
             } else {


### PR DESCRIPTION
The paper-added getOrigin method can return a Location with a null world, which is unable to be adapted with BukkitAdapter#adapt

This fixes the error seen in IntellectualSites/FastAsyncWorldEdit#1621