### PR TITLE
Implement ProtectedPolygonalRegion volume method (from WE)

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -27,6 +27,8 @@ import com.sk89q.worldedit.math.BlockVector3;
 
 import java.awt.Polygon;
 import java.awt.geom.Area;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -184,8 +186,22 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
 
     @Override
     public int volume() {
-        // TODO: Fix this -- the previous algorithm returned incorrect results, but the current state of this method is even worse
-        return 0;
+      long area = 0;
+      int i;
+      int j = points.size() - 1;
+  
+      for (i = 0; i < points.size(); ++i) {
+        long x = points.get(j).getBlockX() + points.get(i).getBlockX();
+        long z = points.get(j).getBlockZ() - points.get(i).getBlockZ();
+        area += x * z;
+        j = i;
+      }
+  
+      return (int) BigDecimal.valueOf(area)
+                    .multiply(BigDecimal.valueOf(0.5))
+                    .abs()
+                    .setScale(0, RoundingMode.FLOOR)
+                    .longValue() * (maxY - minY + 1);
     }
 
 }


### PR DESCRIPTION
Reimplemented polygonal volume calculation, based on that used for the //size WorldEdit command (please see [here](https://github.com/EngineHub/WorldEdit/blob/b8a9c0070c72bbdd0d2c77fa8c537c01b0f73f85/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Polygonal2DRegion.java#getVolume():~:text=public%20long-,getVolume,-()%20%7B)).

I'm not sure why this is valid for WorldEdit but not WorldGuard - I'd appreciate some clarification on why this is the case (or if it was just missed that's fine too!)