### PR TITLE
Introduce uninitialize for sessions

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldGuardPlatform.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldGuardPlatform.java
@@ -146,6 +146,7 @@ public class BukkitWorldGuardPlatform implements WorldGuardPlatform {
 
     @Override
     public void unload() {
+        sessionManager.shutdown();
         configuration.unload();
         regionContainer.shutdown();
     }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
@@ -148,6 +148,8 @@ public class PlayerMoveListener extends AbstractListener {
         if (loc != null) {
             player.teleport(BukkitAdapter.adapt(loc));
         }
+
+        session.uninitialize(localPlayer);
     }
 
     private class EntityMountListener implements Listener {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/session/BukkitSessionManager.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/session/BukkitSessionManager.java
@@ -100,4 +100,11 @@ public class BukkitSessionManager extends AbstractSessionManager implements Runn
     public void setUsingTimings(boolean useTimings) {
         this.useTimings = useTimings;
     }
+
+    public void shutdown() {
+        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
+            LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+            get(localPlayer).uninitialize(localPlayer);
+        }
+    }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
@@ -121,6 +121,21 @@ public class Session {
     }
 
     /**
+     * Uninitialize the session.
+     *
+     * @param player The player
+     */
+    public void uninitialize(LocalPlayer player) {
+        RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
+        Location location = player.getLocation();
+        ApplicableRegionSet set = query.getApplicableRegions(location);
+
+        for (Handler handler : handlers.values()) {
+            handler.uninitialize(player, location, set);
+        }
+    }
+
+    /**
      * Tick the session.
      *
      * @param player The player

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/FlagValueChangeHandler.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/FlagValueChangeHandler.java
@@ -47,7 +47,7 @@ public abstract class FlagValueChangeHandler<T> extends Handler {
 
     @Override
     public final void uninitialize(LocalPlayer player, Location current, ApplicableRegionSet set) {
-        onAbsentValue(player, current, current, set, lastValue, MoveType.OTHER_NON_CANCELLABLE);
+        onClearValue(player, set);
         lastValue = null;
     }
 
@@ -80,4 +80,8 @@ public abstract class FlagValueChangeHandler<T> extends Handler {
 
     protected abstract boolean onAbsentValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet toSet, T lastValue, MoveType moveType);
 
+    protected void onClearValue(LocalPlayer player, ApplicableRegionSet set) {
+        Location current = player.getLocation();
+        onAbsentValue(player, current, current, set, lastValue, MoveType.OTHER_NON_CANCELLABLE);
+    }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/FlagValueChangeHandler.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/FlagValueChangeHandler.java
@@ -46,6 +46,12 @@ public abstract class FlagValueChangeHandler<T> extends Handler {
     }
 
     @Override
+    public final void uninitialize(LocalPlayer player, Location current, ApplicableRegionSet set) {
+        onAbsentValue(player, current, current, set, lastValue, MoveType.OTHER_NON_CANCELLABLE);
+        lastValue = null;
+    }
+
+    @Override
     public boolean onCrossBoundary(LocalPlayer player, Location from, Location to, ApplicableRegionSet toSet, Set<ProtectedRegion> entered, Set<ProtectedRegion> exited, MoveType moveType) {
         if (entered.isEmpty() && exited.isEmpty()
                 && from.getExtent().equals(to.getExtent())) { // sets don't include global regions - check if those changed

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/Handler.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/Handler.java
@@ -75,6 +75,16 @@ public abstract class Handler {
     }
 
     /**
+     * Called when the session should clear its caches.
+     *
+     * @param player The player
+     * @param current The player's current location
+     * @param set The regions for the current location
+     */
+    public void uninitialize(LocalPlayer player, Location current, ApplicableRegionSet set) {
+    }
+
+    /**
      * Called when {@link Session#testMoveTo(LocalPlayer, Location, MoveType)} is called.
      *
      * <p>If this method returns {@code false}, then no other handlers


### PR DESCRIPTION
Introduces uninitialize for sessions that is called when the player disconnects or the server is shut down. Currently handlers don't get any notifications when the mentioned events occur and are unable to restore any player state they are holding to.

For example, this can be seen when entering to a region in survival with a `game-mode creative` flag, disconnecting and waiting for the session to timeout. When connecting back to the server and walking out of the region you can see that the player is not switched back to survival as they normally would be.