### PR TITLE
Improve compatibility with the new onClearValue

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/FlagValueChangeHandler.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/FlagValueChangeHandler.java
@@ -81,7 +81,9 @@ public abstract class FlagValueChangeHandler<T> extends Handler {
     protected abstract boolean onAbsentValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet toSet, T lastValue, MoveType moveType);
 
     protected void onClearValue(LocalPlayer player, ApplicableRegionSet set) {
-        Location current = player.getLocation();
-        onAbsentValue(player, current, current, set, lastValue, MoveType.OTHER_NON_CANCELLABLE);
+        if (lastValue != null) {
+            Location current = player.getLocation();
+            onAbsentValue(player, current, current, set, lastValue, MoveType.OTHER_NON_CANCELLABLE);
+        }
     }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/NotifyExitFlag.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/handler/NotifyExitFlag.java
@@ -59,4 +59,8 @@ public class NotifyExitFlag extends FlagValueChangeHandler<Boolean> {
         WorldGuard.getInstance().getPlatform().broadcastNotification(new Notify(player.getName(), " left NOTIFY region").create());
         return true;
     }
+
+    @Override
+    protected void onClearValue(LocalPlayer player, ApplicableRegionSet set) {
+    }
 }


### PR DESCRIPTION
Added null check to the default implementation of `onClearValue` as some handlers might not expect it to be called at that point.

Overriding the `onClearValue` in the `NotifyExitFlag` to not trigger it on disconnect to keep the old behavior.