### PR TITLE
Fix, simplify and optimize AbstractRegionOverlapAssociation

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java
@@ -24,12 +24,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.sk89q.worldguard.domains.Association;
 import com.sk89q.worldguard.protection.FlagValueCalculator;
 import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -37,9 +37,9 @@ public abstract class AbstractRegionOverlapAssociation implements RegionAssociab
 
     @Nullable
     protected Set<ProtectedRegion> source;
-    private boolean useMaxPriorityAssociation;
+    private boolean effectivelyEmpty;
+    private final boolean useMaxPriorityAssociation;
     private int maxPriority;
-    private Set<ProtectedRegion> maxPriorityRegions;
 
     protected AbstractRegionOverlapAssociation(@Nullable Set<ProtectedRegion> source, boolean useMaxPriorityAssociation) {
         this.source = source;
@@ -48,36 +48,53 @@ public abstract class AbstractRegionOverlapAssociation implements RegionAssociab
 
     protected void calcMaxPriority() {
         checkNotNull(source);
-        int best = 0;
-        Set<ProtectedRegion> bestRegions = new HashSet<>();
+        boolean effectivelyEmpty = true;
+        int maxPriority = Integer.MIN_VALUE;
+
         for (ProtectedRegion region : source) {
             int priority = region.getPriority();
-            if (priority > best) {
-                best = priority;
-                bestRegions.clear();
-                bestRegions.add(region);
-            } else if (priority == best) {
-                bestRegions.add(region);
+
+            // Potential endless recurrence? No, because there is no region group flag.
+            if ((effectivelyEmpty || priority > maxPriority) && FlagValueCalculator.getEffectiveFlagOf(region, Flags.PASSTHROUGH, this) != State.ALLOW) {
+                effectivelyEmpty = false;
+
+                if (useMaxPriorityAssociation) {
+                    maxPriority = priority;
+                } else {
+                    break;
+                }
             }
         }
-        this.maxPriority = best;
-        this.maxPriorityRegions = bestRegions;
+
+        this.effectivelyEmpty = effectivelyEmpty;
+        this.maxPriority = maxPriority;
     }
 
-    private boolean checkNonplayerProtectionDomains(Iterable<? extends ProtectedRegion> source, Collection<?> domains) {
-        if (source == null || domains == null || domains.isEmpty()) {
+    private boolean checkNonplayerProtectionDomains(ProtectedRegion region) {
+        if (source.isEmpty()) {
             return false;
         }
 
-        for (ProtectedRegion region : source) {
-            // Potential endless recurrence? No, because there is no region group flag.
-            Set<String> regionDomains = FlagValueCalculator.getEffectiveFlagOf(region, Flags.NONPLAYER_PROTECTION_DOMAINS, this);
+        // Potential endless recurrence? No, because there is no region group flag.
+        Set<String> domains = FlagValueCalculator.getEffectiveFlagOf(region, Flags.NONPLAYER_PROTECTION_DOMAINS, this);
 
-            if (regionDomains == null || regionDomains.isEmpty()) {
+        if (domains == null || domains.isEmpty()) {
+            return false;
+        }
+
+        for (ProtectedRegion sourceRegion : source) {
+            if (sourceRegion.getPriority() < maxPriority) {
                 continue;
             }
 
-            if (!Collections.disjoint(regionDomains, domains)) {
+            // Potential endless recurrence? No, because there is no region group flag.
+            Set<String> sourceDomains = FlagValueCalculator.getEffectiveFlagOf(sourceRegion, Flags.NONPLAYER_PROTECTION_DOMAINS, this);
+
+            if (sourceDomains == null || sourceDomains.isEmpty()) {
+                continue;
+            }
+
+            if (!Collections.disjoint(sourceDomains, domains)) {
                 return true;
             }
         }
@@ -90,31 +107,15 @@ public abstract class AbstractRegionOverlapAssociation implements RegionAssociab
         checkNotNull(source);
         for (ProtectedRegion region : regions) {
             while (region != null) {
-                if ((region.getId().equals(ProtectedRegion.GLOBAL_REGION) && source.isEmpty())) {
+                if (region.getId().equals(ProtectedRegion.GLOBAL_REGION) && effectivelyEmpty) {
                     return Association.OWNER;
                 }
 
-                if (source.contains(region)) {
-                    if (useMaxPriorityAssociation) {
-                        int priority = region.getPriority();
-                        if (priority == maxPriority) {
-                            return Association.OWNER;
-                        }
-                    } else {
-                        return Association.OWNER;
-                    }
+                if (source.contains(region) && region.getPriority() >= maxPriority) {
+                    return Association.OWNER;
                 }
 
-                Set<ProtectedRegion> source;
-
-                if (useMaxPriorityAssociation) {
-                    source = maxPriorityRegions;
-                } else {
-                    source = this.source;
-                }
-
-                // Potential endless recurrence? No, because there is no region group flag.
-                if (checkNonplayerProtectionDomains(source, FlagValueCalculator.getEffectiveFlagOf(region, Flags.NONPLAYER_PROTECTION_DOMAINS, this))) {
+                if (checkNonplayerProtectionDomains(region)) {
                     return Association.OWNER;
                 }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -45,7 +45,7 @@ public final class Flags {
     public static final List<String> INBUILT_FLAGS = Collections.unmodifiableList(INBUILT_FLAGS_LIST);
 
     // Overrides membership check
-    public static final StateFlag PASSTHROUGH = register(new StateFlag("passthrough", false));
+    public static final StateFlag PASSTHROUGH = register(new StateFlag("passthrough", false, null));
     public static final SetFlag<String> NONPLAYER_PROTECTION_DOMAINS = register(new SetFlag<>("nonplayer-protection-domains", null, new StringFlag(null)));
 
     // This flag is unlike the others. It forces the checking of region membership

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/registry/SimpleFlagRegistry.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/registry/SimpleFlagRegistry.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -162,7 +163,11 @@ public class SimpleFlagRegistry implements FlagRegistry {
                     values.put(unk, entry.getValue());
                 }
             } else {
-                values.put(parent.getRegionGroupFlag(), parent.getRegionGroupFlag().unmarshal(entry.getValue()));
+                RegionGroupFlag regionGroupFlag = parent.getRegionGroupFlag();
+
+                if (regionGroupFlag != null) {
+                    values.put(regionGroupFlag, regionGroupFlag.unmarshal(entry.getValue()));
+                }
             }
         }
 


### PR DESCRIPTION
This pr fixes two issues:

1. [This variable](https://github.com/EngineHub/WorldGuard/blob/741f9e231b80bfb7e17a73157e3443bf535b32e7/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java#L51) should be initialized with `Integer.MIN_VALUE` instead of `0`.
2. An issue that Theosis#0001 talked about in [this message](https://discord.com/channels/80853743897149440/470410381597343753/869561221689536522) on Discord.
![grafik](https://user-images.githubusercontent.com/18699205/195721446-7fa6160d-6dc9-46ef-b550-0989ed9ca0ac.png)
![grafik](https://user-images.githubusercontent.com/18699205/195721640-94d24133-abc6-4d3d-adb1-9e9a7d3f97f0.png)
In general this can also happen with normal regions when the config setting `use-max-priority-association` is set to `true` (e.g. by overlapping a protected region and a higher priority region with passthrough set to allow). As noted in the [docs](https://worldguard.enginehub.org/en/latest/regions/global-region/#non-player-associables), the global region always behaves as if `use-max-priority-association` is set to `true` (due to legacy reasons I guess). [That's why](https://github.com/EngineHub/WorldGuard/blob/741f9e231b80bfb7e17a73157e3443bf535b32e7/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java#L93) this also happens for the global region, even if `use-max-priority-association` is set to `false`. My solution to this problem is to ignore regions with passthrough set to allow, when calculating the maximum priority [here](https://github.com/EngineHub/WorldGuard/blob/741f9e231b80bfb7e17a73157e3443bf535b32e7/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java#L49-L65) and later checking for `>=` [here](https://github.com/EngineHub/WorldGuard/blob/741f9e231b80bfb7e17a73157e3443bf535b32e7/worldguard-core/src/main/java/com/sk89q/worldguard/protection/association/AbstractRegionOverlapAssociation.java#L100). Equivalently the global region is fixed by treating nonplayers as members not only when the source of regions is empty, but also when the source only contains regions with passthrough set to allow (which I call `effectivelyEmpty`).

I was also able to simplify and optimize some parts while fixing those issues and I have cleaned up a bit. E.g. `#getAssociation(List<ProtectedRegion>)` now uses the same logic, regardless of whether or not `use-max-priority-association` is enabled (it's just controlled by the calculated maximum priority). Also calculating the maximum priority returns fast if `use-max-priority-association` is disabled and it no longer allocates a new `HashSet`.

Unfortunately, checking flags (like passthrough) can itself depend on membership (`#getAssociation`), if there's an associated region group flag. This would lead to endless recursions when doing this while calculating the membership. That's why I have removed the passthrough region group flag, which explains the required changes in [Flags](https://github.com/EngineHub/WorldGuard/blob/741f9e231b80bfb7e17a73157e3443bf535b32e7/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java) and [SimpleFlagRegistry](https://github.com/EngineHub/WorldGuard/blob/741f9e231b80bfb7e17a73157e3443bf535b32e7/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/registry/SimpleFlagRegistry.java) in case someone has set it. However, I think setting a region group for the passthrough flag doesn't make much sense anyway.