### PR TITLE
Add additional holder snapshot bypasses for performance

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/InventoryMoveItemEventDebounce.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/InventoryMoveItemEventDebounce.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldguard.bukkit.listener.debounce.legacy;
 
 import com.sk89q.worldguard.bukkit.listener.debounce.legacy.InventoryMoveItemEventDebounce.Key;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -44,9 +45,9 @@ public class InventoryMoveItemEventDebounce extends AbstractEventDebounce<Key> {
         private final Object target;
 
         public Key(InventoryMoveItemEvent event) {
-            cause = transform(event.getInitiator().getHolder());
-            source = transform(event.getSource().getHolder());
-            target = transform(event.getDestination().getHolder());
+            cause = transform(PaperLib.getHolder(event.getInitiator(), false).getHolder());
+            source = transform(PaperLib.getHolder(event.getSource(), false).getHolder());
+            target = transform(PaperLib.getHolder(event.getDestination(), false).getHolder());
         }
 
         private Object transform(InventoryHolder holder) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/InventoryMoveItemEventDebounce.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/InventoryMoveItemEventDebounce.java
@@ -51,12 +51,12 @@ public class InventoryMoveItemEventDebounce extends AbstractEventDebounce<Key> {
         }
 
         private Object transform(InventoryHolder holder) {
-            if (holder instanceof BlockState) {
-                return new BlockMaterialKey(((BlockState) holder).getBlock());
-            } else if (holder instanceof DoubleChest) {
-                InventoryHolder left = ((DoubleChest) holder).getLeftSide();
-                if (left instanceof Chest) {
-                    return new BlockMaterialKey(((Chest) left).getBlock());
+            if (holder instanceof BlockState blockState) {
+                return new BlockMaterialKey(blockState);
+            } else if (holder instanceof DoubleChest doubleChest) {
+                InventoryHolder left = doubleChest.getLeftSide();
+                if (left instanceof Chest chest) {
+                    return new BlockMaterialKey(chest);
                 } else {
                     return holder;
                 }
@@ -95,8 +95,8 @@ public class InventoryMoveItemEventDebounce extends AbstractEventDebounce<Key> {
         private final Block block;
         private final Material material;
 
-        private BlockMaterialKey(Block block) {
-            this.block = block;
+        private BlockMaterialKey(BlockState block) {
+            this.block = block.getBlock();
             material = block.getType();
         }
 


### PR DESCRIPTION
I noticed holders are being accessed from potentially block inventories here too, and arguably at a much higher rate than in the main event handler. 

Unsure if this has any side effects, as there are some instances where it seems to not return just the block itself. From what I can tell, the hashCode & equals methods only care about the location and the underlying MC blockstate (so block type & properties), which is a snapshot even when snapshots are false in Paper (as that only cares about NBT). So, this _should_ be fine. Only risk is if something overrides this in the future, but currently nothing does.

Also added an extra optimisation where it grabs the Material from the BlockState rather than the block, preventing a world lookup (on Paper; Spigot still calls the world here)