### PR TITLE
Fix NPE when non-player entities create new nether portals

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -661,8 +661,8 @@ public class WorldGuardEntityListener extends AbstractListener {
                 && event.getReason() == PortalCreateEvent.CreateReason.NETHER_PAIR
                 && !event.getBlocks().isEmpty()) {
             final com.sk89q.worldedit.world.World world = BukkitAdapter.adapt(event.getWorld());
-            LocalPlayer localPlayer = null;
             final Cause cause = Cause.create(event.getEntity());
+            LocalPlayer localPlayer = null;
             if (cause.getRootCause() instanceof Player player) {
                 if (wcfg.fakePlayerBuildOverride && InteropUtils.isFakePlayer(player)) {
                     return;
@@ -688,7 +688,7 @@ public class WorldGuardEntityListener extends AbstractListener {
                 ProtectedCuboidRegion target = new ProtectedCuboidRegion("__portal_check", true, min, max);
                 regions = regionManager.getApplicableRegions(target);
             }
-            RegionAssociable associable = createRegionAssociable(cause);
+            final RegionAssociable associable = createRegionAssociable(cause);
             final State buildState = StateFlag.denyToNone(regions.queryState(associable, Flags.BUILD));
             if (!StateFlag.test(buildState, regions.queryState(associable, Flags.BLOCK_BREAK))
                     || !StateFlag.test(buildState, regions.queryState(associable, Flags.BLOCK_PLACE))) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -34,6 +34,7 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
@@ -682,7 +683,10 @@ public class WorldGuardEntityListener extends AbstractListener {
             }
             ProtectedCuboidRegion target = new ProtectedCuboidRegion("__portal_check", true, min, max);
             final ApplicableRegionSet regions = regionManager.getApplicableRegions(target);
-            if (!regions.testState(createRegionAssociable(cause), Flags.BUILD, Flags.BLOCK_PLACE)) {
+            RegionAssociable associable = createRegionAssociable(cause);
+            final State buildState = StateFlag.denyToNone(regions.queryState(associable, Flags.BUILD));
+            if (!StateFlag.test(buildState, regions.queryState(associable, Flags.BLOCK_BREAK))
+                    || !StateFlag.test(buildState, regions.queryState(associable, Flags.BLOCK_PLACE))) {
                 if (localPlayer != null && !cause.isIndirect()) {
                     // NB there is no way to cancel the teleport without PTA (since PlayerPortal doesn't have block info)
                     // removing PTA was a mistake


### PR DESCRIPTION
Resolves #1993. <strike>I didn't test this yet (will do later).</strike> Note that the (root) causing entity might be in a different world than the created portal, which means that the action will be blocked in a protected region by default (provided that Vanilla even allows this, which isn't the case currently).