### PR TITLE
Synchronize YamlRegionFile#saveAll

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/file/YamlRegionFile.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/file/YamlRegionFile.java
@@ -191,66 +191,68 @@ public class YamlRegionFile implements RegionDatabase {
     }
 
     @Override
-    public synchronized void saveAll(Set<ProtectedRegion> regions) throws StorageException {
+    public void saveAll(Set<ProtectedRegion> regions) throws StorageException {
         checkNotNull(regions);
 
-        File tempFile = new File(file.getParentFile(), file.getName() + ".tmp");
-        YAMLProcessor config = createYamlProcessor(tempFile);
+        synchronized (YamlRegionFile.class) {
+            File tempFile = new File(file.getParentFile(), file.getName() + ".tmp");
+            YAMLProcessor config = createYamlProcessor(tempFile);
 
-        config.clear();
+            config.clear();
 
-        YAMLNode regionsNode = config.addNode("regions");
-        Map<String, Object> map = regionsNode.getMap();
+            YAMLNode regionsNode = config.addNode("regions");
+            Map<String, Object> map = regionsNode.getMap();
 
-        for (ProtectedRegion region : regions) {
-            Map<String, Object> nodeMap = new HashMap<>();
-            map.put(region.getId(), nodeMap);
-            YAMLNode node = new YAMLNode(nodeMap, false);
+            for (ProtectedRegion region : regions) {
+                Map<String, Object> nodeMap = new HashMap<>();
+                map.put(region.getId(), nodeMap);
+                YAMLNode node = new YAMLNode(nodeMap, false);
 
-            if (region instanceof ProtectedCuboidRegion) {
-                ProtectedCuboidRegion cuboid = (ProtectedCuboidRegion) region;
-                node.setProperty("type", "cuboid");
-                node.setProperty("min", cuboid.getMinimumPoint());
-                node.setProperty("max", cuboid.getMaximumPoint());
-            } else if (region instanceof ProtectedPolygonalRegion) {
-                ProtectedPolygonalRegion poly = (ProtectedPolygonalRegion) region;
-                node.setProperty("type", "poly2d");
-                node.setProperty("min-y", poly.getMinimumPoint().y());
-                node.setProperty("max-y", poly.getMaximumPoint().y());
+                if (region instanceof ProtectedCuboidRegion) {
+                    ProtectedCuboidRegion cuboid = (ProtectedCuboidRegion) region;
+                    node.setProperty("type", "cuboid");
+                    node.setProperty("min", cuboid.getMinimumPoint());
+                    node.setProperty("max", cuboid.getMaximumPoint());
+                } else if (region instanceof ProtectedPolygonalRegion) {
+                    ProtectedPolygonalRegion poly = (ProtectedPolygonalRegion) region;
+                    node.setProperty("type", "poly2d");
+                    node.setProperty("min-y", poly.getMinimumPoint().y());
+                    node.setProperty("max-y", poly.getMaximumPoint().y());
 
-                List<Map<String, Object>> points = new ArrayList<>();
-                for (BlockVector2 point : poly.getPoints()) {
-                    Map<String, Object> data = new HashMap<>();
-                    data.put("x", point.x());
-                    data.put("z", point.z());
-                    points.add(data);
+                    List<Map<String, Object>> points = new ArrayList<>();
+                    for (BlockVector2 point : poly.getPoints()) {
+                        Map<String, Object> data = new HashMap<>();
+                        data.put("x", point.x());
+                        data.put("z", point.z());
+                        points.add(data);
+                    }
+
+                    node.setProperty("points", points);
+                } else if (region instanceof GlobalProtectedRegion) {
+                    node.setProperty("type", "global");
+                } else {
+                    node.setProperty("type", region.getClass().getCanonicalName());
                 }
 
-                node.setProperty("points", points);
-            } else if (region instanceof GlobalProtectedRegion) {
-                node.setProperty("type", "global");
-            } else {
-                node.setProperty("type", region.getClass().getCanonicalName());
+                node.setProperty("priority", region.getPriority());
+                node.setProperty("flags", getFlagData(region));
+                node.setProperty("owners", getDomainData(region.getOwners()));
+                node.setProperty("members", getDomainData(region.getMembers()));
+
+                ProtectedRegion parent = region.getParent();
+                if (parent != null) {
+                    node.setProperty("parent", parent.getId());
+                }
             }
 
-            node.setProperty("priority", region.getPriority());
-            node.setProperty("flags", getFlagData(region));
-            node.setProperty("owners", getDomainData(region.getOwners()));
-            node.setProperty("members", getDomainData(region.getMembers()));
+            config.setHeader(FILE_HEADER);
+            config.save();
 
-            ProtectedRegion parent = region.getParent();
-            if (parent != null) {
-                node.setProperty("parent", parent.getId());
+            //noinspection ResultOfMethodCallIgnored
+            file.delete();
+            if (!tempFile.renameTo(file)) {
+                throw new StorageException("Failed to rename temporary regions file to " + file.getAbsolutePath());
             }
-        }
-
-        config.setHeader(FILE_HEADER);
-        config.save();
-
-        //noinspection ResultOfMethodCallIgnored
-        file.delete();
-        if (!tempFile.renameTo(file)) {
-            throw new StorageException("Failed to rename temporary regions file to " + file.getAbsolutePath());
         }
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/file/YamlRegionFile.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/file/YamlRegionFile.java
@@ -191,7 +191,7 @@ public class YamlRegionFile implements RegionDatabase {
     }
 
     @Override
-    public void saveAll(Set<ProtectedRegion> regions) throws StorageException {
+    public synchronized void saveAll(Set<ProtectedRegion> regions) throws StorageException {
         checkNotNull(regions);
 
         File tempFile = new File(file.getParentFile(), file.getName() + ".tmp");


### PR DESCRIPTION
This prevents multiple invocations of the method from intersecting, which could potentially cause the .tmp file to be overwritten before being renamed, thus corrupting the region storage