### PR TITLE
Add command plugin compatability into GeneralCommands

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitConfigurationManager.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitConfigurationManager.java
@@ -37,6 +37,7 @@ public class BukkitConfigurationManager extends YamlConfigurationManager {
 
     private boolean hasCommandBookGodMode;
     boolean extraStats;
+    private boolean hasEssentialsGodMode;
 
     /**
      * Construct the object.
@@ -123,5 +124,13 @@ public class BukkitConfigurationManager extends YamlConfigurationManager {
 
     public boolean hasCommandBookGodMode() {
         return hasCommandBookGodMode;
+    }
+
+    public void updateEssentialsGodMode() {
+        hasEssentialsGodMode = plugin.getServer().getPluginManager().isPluginEnabled("Essentials");
+    }
+
+    public boolean hasEssentialsGodMode() {
+        return hasEssentialsGodMode;
     }
 }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -160,7 +160,10 @@ public class WorldGuardPlugin extends JavaPlugin {
         reg.register(ToggleCommands.class);
         reg.register(ProtectionCommands.class);
 
-        if (!platform.getGlobalStateManager().hasCommandBookGodMode()) {
+        platform.getGlobalStateManager().updateCommandBookGodMode();
+        platform.getGlobalStateManager().updateEssentialsGodMode();
+
+        if (!platform.getGlobalStateManager().hasCommandBookGodMode() && !platform.getGlobalStateManager().hasEssentialsGodMode()) {
             reg.register(GeneralCommands.class);
         }
 
@@ -191,8 +194,6 @@ public class WorldGuardPlugin extends JavaPlugin {
         if ("true".equalsIgnoreCase(System.getProperty("worldguard.debug.listener"))) {
             (new DebuggingListener(this, WorldGuard.logger)).registerEvents();
         }
-
-        platform.getGlobalStateManager().updateCommandBookGodMode();
 
         if (getServer().getPluginManager().isPluginEnabled("CommandBook")) {
             getServer().getPluginManager().registerEvents(new WorldGuardCommandBookListener(this), this);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -63,6 +63,7 @@ import com.sk89q.worldguard.bukkit.util.ClassSourceValidator;
 import com.sk89q.worldguard.bukkit.util.Entities;
 import com.sk89q.worldguard.bukkit.util.Events;
 import com.sk89q.worldguard.commands.GeneralCommands;
+import com.sk89q.worldguard.commands.GeneralCompatibleCommands;
 import com.sk89q.worldguard.commands.ProtectionCommands;
 import com.sk89q.worldguard.commands.ToggleCommands;
 import com.sk89q.worldguard.domains.registry.SimpleDomainRegistry;
@@ -165,6 +166,8 @@ public class WorldGuardPlugin extends JavaPlugin {
 
         if (!platform.getGlobalStateManager().hasCommandBookGodMode() && !platform.getGlobalStateManager().hasEssentialsGodMode()) {
             reg.register(GeneralCommands.class);
+        }else{
+            reg.register(GeneralCompatibleCommands.class);
         }
 
         getServer().getScheduler().scheduleSyncRepeatingTask(this, sessionManager, BukkitSessionManager.RUN_DELAY, BukkitSessionManager.RUN_DELAY);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardServerListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardServerListener.java
@@ -35,12 +35,20 @@ public class WorldGuardServerListener extends AbstractListener {
         if (event.getPlugin().getDescription().getName().equalsIgnoreCase("CommandBook")) {
             getConfig().updateCommandBookGodMode();
         }
+
+        if(event.getPlugin().getDescription().getName().equalsIgnoreCase("Essentials")){
+            getConfig().updateEssentialsGodMode();
+        }
     }
 
     @EventHandler
     public void onPluginDisable(PluginDisableEvent event) {
         if (event.getPlugin().getDescription().getName().equalsIgnoreCase("CommandBook")) {
             getConfig().updateCommandBookGodMode();
+        }
+
+        if(event.getPlugin().getDescription().getName().equalsIgnoreCase("Essentials")){
+            getConfig().updateEssentialsGodMode();
         }
     }
 }

--- a/worldguard-bukkit/src/main/resources/defaults/config.yml
+++ b/worldguard-bukkit/src/main/resources/defaults/config.yml
@@ -12,7 +12,7 @@
 # - If you want to check the format of this file before putting it
 #   into WorldGuard, paste it into http://yaml-online-parser.appspot.com/
 #   and see if it gives "ERROR:".
-# - Lines starting with # are commentsand so they are ignored.
+# - Lines starting with # are comments and so they are ignored.
 #
 # WARNING:
 # Remember to check the compatibility spreadsheet for WorldGuard to see

--- a/worldguard-bukkit/src/main/resources/plugin.yml
+++ b/worldguard-bukkit/src/main/resources/plugin.yml
@@ -2,5 +2,5 @@ name: WorldGuard
 main: com.sk89q.worldguard.bukkit.WorldGuardPlugin
 version: "${internalVersion}"
 depend: [WorldEdit]
-softdepend: [CommandBook]
+softdepend: [CommandBook, Essentials]
 api-version: "1.20"

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/GeneralCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/GeneralCommands.java
@@ -39,7 +39,7 @@ public class GeneralCommands {
         this.worldGuard = worldGuard;
     }
     
-    @Command(aliases = {"god"}, usage = "[player]",
+    @Command(aliases = {"god", "wggod"}, usage = "[player]",
             desc = "Enable godmode on a player", flags = "s", max = 1)
     public void god(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
         Iterable<? extends LocalPlayer> targets = null;
@@ -84,7 +84,7 @@ public class GeneralCommands {
         }
     }
     
-    @Command(aliases = {"ungod"}, usage = "[player]",
+    @Command(aliases = {"ungod", "wgungod"}, usage = "[player]",
             desc = "Disable godmode on a player", flags = "s", max = 1)
     public void ungod(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
         Iterable<? extends LocalPlayer> targets;
@@ -127,7 +127,7 @@ public class GeneralCommands {
         }
     }
     
-    @Command(aliases = {"heal"}, usage = "[player]", desc = "Heal a player", flags = "s", max = 1)
+    @Command(aliases = {"heal", "wgheal"}, usage = "[player]", desc = "Heal a player", flags = "s", max = 1)
     public void heal(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
 
         Iterable<? extends LocalPlayer> targets = null;
@@ -171,7 +171,7 @@ public class GeneralCommands {
         }
     }
     
-    @Command(aliases = {"slay"}, usage = "[player]", desc = "Slay a player", flags = "s", max = 1)
+    @Command(aliases = {"slay", "wgslay"}, usage = "[player]", desc = "Slay a player", flags = "s", max = 1)
     public void slay(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
         
         Iterable<? extends LocalPlayer> targets = Lists.newArrayList();
@@ -212,7 +212,7 @@ public class GeneralCommands {
         }
     }
     
-    @Command(aliases = {"locate"}, usage = "[player]", desc = "Locate a player", max = 1)
+    @Command(aliases = {"locate", "locate"}, usage = "[player]", desc = "Locate a player", max = 1)
     @CommandPermissions({"worldguard.locate"})
     public void locate(CommandContext args, Actor sender) throws CommandException {
         LocalPlayer player = worldGuard.checkPlayer(sender);
@@ -229,7 +229,7 @@ public class GeneralCommands {
         }
     }
     
-    @Command(aliases = {"stack", ";"}, usage = "", desc = "Stack items", max = 0)
+    @Command(aliases = {"stack", "wgstack", ";"}, usage = "", desc = "Stack items", max = 0)
     @CommandPermissions({"worldguard.stack"})
     public void stack(CommandContext args, Actor sender) throws CommandException {
         LocalPlayer player = worldGuard.checkPlayer(sender);
@@ -238,4 +238,6 @@ public class GeneralCommands {
 
         player.print("Items compacted into stacks!");
     }
+
+
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/GeneralCompatibleCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/GeneralCompatibleCommands.java
@@ -1,0 +1,51 @@
+package com.sk89q.worldguard.commands;
+
+import com.sk89q.minecraft.util.commands.Command;
+import com.sk89q.minecraft.util.commands.CommandContext;
+import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.CommandPermissions;
+import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.util.auth.AuthorizationException;
+import com.sk89q.worldguard.WorldGuard;
+
+public class GeneralCompatibleCommands {
+    private final GeneralCommands generalCommands;
+
+    public GeneralCompatibleCommands(WorldGuard worldGuard) {
+        this.generalCommands = new GeneralCommands(worldGuard);
+    }
+
+    @Command(aliases = {"wggod"}, usage = "[player]",
+            desc = "Enable godmode on a player", flags = "s", max = 1)
+    public void god(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
+        generalCommands.god(args, sender);
+    }
+
+    @Command(aliases = {"wgungod"}, usage = "[player]",
+            desc = "Disable godmode on a player", flags = "s", max = 1)
+    public void ungod(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
+        generalCommands.ungod(args, sender);
+    }
+
+    @Command(aliases = {"wgheal"}, usage = "[player]", desc = "Heal a player", flags = "s", max = 1)
+    public void heal(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
+        generalCommands.heal(args, sender);
+    }
+
+    @Command(aliases = {"wgslay"}, usage = "[player]", desc = "Slay a player", flags = "s", max = 1)
+    public void slay(CommandContext args, Actor sender) throws CommandException, AuthorizationException {
+        generalCommands.slay(args, sender);
+    }
+
+    @Command(aliases = {"wglocate"}, usage = "[player]", desc = "Locate a player", max = 1)
+    @CommandPermissions({"worldguard.locate"})
+    public void locate(CommandContext args, Actor sender) throws CommandException {
+        generalCommands.locate(args, sender);
+    }
+
+    @Command(aliases = {"wgstack", ";"}, usage = "", desc = "Stack items", max = 0)
+    @CommandPermissions({"worldguard.stack"})
+    public void stack(CommandContext args, Actor sender) throws CommandException {
+        generalCommands.stack(args, sender);
+    }
+}


### PR DESCRIPTION
CommandBook compat within WorldGuard was gutted some time ago, but the GeneralCommands don't register when CommandBook is present. This functionality is not identical for similar plugins such as Essentials, which have their commands unexpectedly overridden by WorldGuard.

It's worth noting that all functionality within GeneralCommands is not required for the continued functionality of the plugin. CommandBook support for the CommandBook god mode and detecting it is **entirely disabled** in the current version of WorldGuard, only existing in references to the plugin in the documentation and commented-out code. If this functionality is desired, it should be implemented in a more relevant PR or elsewhere.

This PR makes this functionally identical when using the similar-featured and popular plugin Essentials. Functionality could be added to support other Essentials-like plugins via changing the wording to "Third Party" rather than Essentials and some sort of list, but most complaints seem to be from folks using Essentials.

This PR also adds "GeneralCompatibleCommands", which is basically a wrapper for GeneralCommands with different aliases. I'm not personally familiar with the WorldEdit command system and it seemed the "cleanest" way to handle the alias removal situation would be to just have the wrapper class.

Fixes issue #2013