### PR TITLE
Add disable-general-commands to Bukkit config

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitConfigurationManager.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitConfigurationManager.java
@@ -36,6 +36,7 @@ public class BukkitConfigurationManager extends YamlConfigurationManager {
     @Unreported private ConcurrentMap<String, BukkitWorldConfiguration> worlds = new ConcurrentHashMap<>();
 
     private boolean hasCommandBookGodMode;
+    boolean disableGeneralCommands;
     boolean extraStats;
 
     /**
@@ -56,6 +57,7 @@ public class BukkitConfigurationManager extends YamlConfigurationManager {
     public void load() {
         super.load();
         this.extraStats = getConfig().getBoolean("custom-metrics-charts", true);
+        this.disableGeneralCommands = getConfig().getBoolean("disable-general-commands", false);
     }
 
     @Override

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -160,7 +160,7 @@ public class WorldGuardPlugin extends JavaPlugin {
         reg.register(ToggleCommands.class);
         reg.register(ProtectionCommands.class);
 
-        if (!platform.getGlobalStateManager().hasCommandBookGodMode()) {
+        if (!platform.getGlobalStateManager().disableGeneralCommands && !platform.getGlobalStateManager().hasCommandBookGodMode()) {
             reg.register(GeneralCommands.class);
         }
 


### PR DESCRIPTION
As an alternative, or supplement, to PR #2041, this Pull Request introduces `disable-general-commands`, which can be used to disable the basic commands WorldGuard adds.

Functionality of this change was verified on Paper 1.20.2 git-Paper-280

Resolves most of issue #2013, albeit not terribly elegantly on its own. Still good to have IMO.