### PR TITLE
Fix USE flag being ignored for blocks considered built if used

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -254,7 +254,7 @@ public class RegionProtectionListener extends AbstractListener {
 
             /* Saplings, etc. */
             if (Materials.isConsideredBuildingIfUsed(type)) {
-                canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event));
+                canUse = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.USE));
                 what = "use that";
 
             /* Inventory */


### PR DESCRIPTION
## Fixes issues with the use flag being ignored when players attempt to modify a block state.

RegionProtectionListener did not attach any flags for materials which fall under the isConsideredBuildingIfUsed category. Without any flag being combined into the event, the interaction would default to using the BUILD flag, which checks the region membership of the player preforming the action. Without the USE flag combined into the event, the state of the flag would not change the behavior.

The affected blocks are: repeaters, comparators, cake, dragon eggs, flower pots, candles, and candles on cake.

This PR combines USE flag into the isConsideredBuildingIfUsed category inside the onUseBlock event.

This issue was originally found on 7.0.9, and also identified in 7.1.0, the latest revision of master branch.

---

Before the change:

https://github.com/EngineHub/WorldGuard/assets/25551899/af4db8b7-fafa-40e2-b361-15ca13359b34



After the change:

https://github.com/EngineHub/WorldGuard/assets/25551899/0016688c-6197-40ba-93c0-10e6ed4433c2

---

<details><summary>Region flags for above videos</summary>
<p>

- \_\_global__

  - other-explosion: allow
  - lava-fire: allow
  - water-flow: allow
  - use: allow
  - invincible: deny
  - snow-fall: allow
  - leaf-decay: deny
  - firework-damage: deny
  - coral-fade: allow
  - mob-damage: allow
  - ravager-grief: allow
  - use-anvil: allow
  - respawn-anchors: deny
  - mushroom-growth: allow
  - block-break-group: NON_MEMBERS
  - lightning: allow
  - ice-form: deny
  - wither-damage: allow
  - enderman-grief: deny
  - pvp: allow
  - mob-spawning: allow
  - crop-growth: allow
  - entry: deny
  - creeper-explosion: deny
  - vine-growth: allow
  - damage-animals: allow
  - snow-melt: allow
  - tnt: allow
  - entity-item-frame-destroy: allow
  - ghast-fireball: deny
  - pvp-group: NON_MEMBERS
  - frosted-ice-form: deny
  - mycelium-spread: allow
  - ice-melt: deny
  - block-trampling: allow
  - vehicle-destroy: allow
  - interact: allow
  - chest-access: allow
  - ride: allow
  - fire-spread: deny
  - enderdragon-block-damage: deny
  - sleep: deny
  - sculk-growth: deny
  - vehicle-place: allow
  - snowman-trails: allow
  - rock-growth: allow
  - block-break: allow
  - entity-painting-destroy: allow
  - lighter: allow
  - use-dripleaf: allow
  - pistons: allow
  - deny-spawn: ['minecraft:villager', 'minecraft:wandering_trader', 'minecraft:enderman', 'minecraft:creeper', 'minecraft:zombie_villager']
  - block-place: allow
  - enderpearl: deny
  - item-drop: allow
  - soil-dry: allow
  - exp-drops: allow
  - copper-fade: allow
  - item-pickup: allow
  - item-frame-rotation: allow
  - potion-splash: allow
  - frosted-ice-melt: deny
  - entry-deny-message: '"§c§lHey! §fThe world border is active! You cannot go this way yet!"'
  - block-place-group: NON_MEMBERS
  - lava-flow: allow
  - grass-growth: allow

- Region tested in

  - entry: allow
  - creeper-explosion: deny
  - use: allow
  - block-break: allow
  - interact: allow
  - deny-spawn: ['minecraft:cave_spider', 'minecraft:villager', 'minecraft:wandering_trader', 'minecraft:skeleton', 'minecraft:enderman', 'minecraft:spider', 'minecraft:zombie', 'minecraft:creeper', 'minecraft:zombie_villager']
  - block-place: allow

</p>
</details>

---

<details><summary>Contributing checklist</summary>
<p>

- [x] Have all tabs been replaced into four spaces? Are indentations 4-space wide?
- [x] Have I written proper Javadocs for my public methods? Are the `@param` and `@return` fields actually filled out?
- [x] Have I git rebased my pull request to the latest commit of the target branch?
- [x] Have I combined my commits into a reasonably small number (if not one) commit using git rebase?
- [x] Have I made my pull request too large? Pull requests should introduce small sets of changes at a time. Major changes should be discussed with the team prior to starting work.
- [x] Are my commit messages descriptive?

</p>
</details> 