### PR TITLE
Add a Paper fast-path for DoubleChest#getLeftSide when possible

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/InventoryMoveItemEventDebounce.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/InventoryMoveItemEventDebounce.java
@@ -54,7 +54,7 @@ public class InventoryMoveItemEventDebounce extends AbstractEventDebounce<Key> {
             if (holder instanceof BlockState blockState) {
                 return new BlockMaterialKey(blockState);
             } else if (holder instanceof DoubleChest doubleChest) {
-                InventoryHolder left = doubleChest.getLeftSide();
+                InventoryHolder left = PaperLib.isPaper() ? doubleChest.getLeftSide(false) : doubleChest.getLeftSide();
                 if (left instanceof Chest chest) {
                     return new BlockMaterialKey(chest);
                 } else {


### PR DESCRIPTION
Simple PR that just adds a Paper fast-path for one of the last remaining places that don't have one.

At some point Paper added a method here (prior to what WG is built to support, so no need for version checks) to allow this, which wasn't possible prior.

This should be the last place that can cause snapshot-related bloat within debounce keys