### PR TITLE
Update WorldGuard to 1.20.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.10
+
+* Add support for MC 1.20.5, drop support for other 1.20 versions
+
 ## 7.0.9
 * Add support for MC 1.20, drop support for MC 1.19
 * Made entities spawned via the `/summon` command get treated as plugin-spawned entities

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -1,11 +1,8 @@
 Compiling
 =========
 
-You can compile WorldGuard as long as you have some version of Java greater than or equal to 17 installed. Gradle will download JDK 17 specifically if needed,
-but it needs some version of Java to bootstrap from.
-
-Note that if you have JRE 17 installed, Gradle will currently attempt to use that to compile, which will not work. It is easiest to uninstall JRE 16 and
-replace it with JDK 17.
+You can compile WorldGuard as long as you have some version of Java greater than or equal to 21 installed. 
+Gradle will download JDK 21 specifically if needed, but it needs some version of Java to bootstrap from.
 
 The build process uses Gradle, which you do *not* need to download. WorldGuard is a multi-module project with three modules:
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,19 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation("gradle.plugin.org.cadixdev.gradle:licenser:0.6.1")
-    implementation("org.ajoberstar.grgit:grgit-gradle:4.1.1")
-    implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
-    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:4.27.1")
+    implementation("org.ajoberstar.grgit:grgit-gradle:5.2.2")
+    implementation("com.github.johnrengelman:shadow:8.1.1")
+    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:5.2.0")
+    constraints {
+        val asmVersion = "[9.7,)"
+        implementation("org.ow2.asm:asm:$asmVersion") {
+            because("Need Java 21 support in shadow")
+        }
+        implementation("org.ow2.asm:asm-commons:$asmVersion") {
+            because("Need Java 21 support in shadow")
+        }
+        implementation("org.vafer:jdependency:[2.10,)") {
+            because("Need Java 21 support in shadow")
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -25,7 +25,7 @@ fun Project.applyCommonConfiguration() {
 
     plugins.withId("java") {
         the<JavaPluginExtension>().toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 

--- a/worldguard-bukkit/build.gradle.kts
+++ b/worldguard-bukkit/build.gradle.kts
@@ -12,6 +12,11 @@ repositories {
         name = "paper"
         url = uri("https://repo.papermc.io/repository/maven-public/")
     }
+    maven {
+        // TODO: Remove this once paper updated to adventure release
+        name = "adventure-snapshots"
+        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    }
 }
 
 configurations {
@@ -20,8 +25,8 @@ configurations {
 
 dependencies {
     "api"(project(":worldguard-core"))
-    "compileOnly"("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
-    "runtimeOnly"("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT") {
+    "compileOnly"("io.papermc.paper:paper-api:1.20.5-R0.1-SNAPSHOT")
+    "runtimeOnly"("org.spigotmc:spigot-api:1.20.5-R0.1-SNAPSHOT") {
         exclude("junit", "junit")
     }
     "api"("com.sk89q.worldedit:worldedit-bukkit:${Versions.WORLDEDIT}") { isTransitive = false }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldGuardPlatform.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldGuardPlatform.java
@@ -266,7 +266,7 @@ public class BukkitWorldGuardPlatform implements WorldGuardPlatform {
                 if (radius > 0) {
                     BlockVector3 spawnLoc = BukkitAdapter.asBlockVector(bWorld.getSpawnLocation());
                     return new ProtectedCuboidRegion("__spawn_protection__",
-                            spawnLoc.subtract(radius, 0, radius).withY(world.getMinimumPoint().getY()),
+                            spawnLoc.subtract(radius, 0, radius).withY(world.getMinimumPoint().y()),
                             spawnLoc.add(radius, 0, radius).withY(world.getMaxY()));
                 }
             }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/BlockedPotionsListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/BlockedPotionsListener.java
@@ -35,6 +35,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Handles blocked potions.
@@ -50,43 +54,50 @@ public class BlockedPotionsListener extends AbstractListener {
         super(plugin);
     }
 
+    private PotionEffectType getBlockedEffectByArrow(Arrow arrow, BukkitWorldConfiguration wcfg) {
+        List<PotionEffect> effects = new ArrayList<>();
+        PotionType potionType = arrow.getBasePotionType();
+        if (potionType != null) {
+            effects.addAll(potionType.getPotionEffects());
+        }
+        effects.addAll(arrow.getCustomEffects());
+        for (PotionEffect potionEffect : effects) {
+            if (wcfg.blockPotions.contains(potionEffect.getType())) {
+                return potionEffect.getType();
+            }
+        }
+        return null;
+    }
+
+
     @EventHandler
     public void onProjectile(DamageEntityEvent event) {
-        if (event.getOriginalEvent() instanceof EntityDamageByEntityEvent) {
-            EntityDamageByEntityEvent originalEvent = (EntityDamageByEntityEvent) event.getOriginalEvent();
-            if (Entities.isPotionArrow(originalEvent.getDamager())) { // should take care of backcompat
-                BukkitWorldConfiguration wcfg = getWorldConfig(event.getWorld());
-                PotionEffectType blockedEffect = null;
-                if (originalEvent.getDamager() instanceof SpectralArrow) {
-                    if (wcfg.blockPotions.contains(PotionEffectType.GLOWING)) {
-                        blockedEffect = PotionEffectType.GLOWING;
-                    }
-                } else if (originalEvent.getDamager() instanceof Arrow) {
-                    Arrow tippedArrow = (Arrow) originalEvent.getDamager();
-                    PotionEffectType baseEffect = tippedArrow.getBasePotionData().getType().getEffectType();
-                    if (wcfg.blockPotions.contains(baseEffect)) {
-                        blockedEffect = baseEffect;
-                    } else {
-                        for (PotionEffect potionEffect : tippedArrow.getCustomEffects()) {
-                            if (wcfg.blockPotions.contains(potionEffect.getType())) {
-                                blockedEffect = potionEffect.getType();
-                                break;
-                            }
-                        }
-                    }
-                }
-                if (blockedEffect != null) {
-                    Player player = event.getCause().getFirstPlayer();
-                    if (player != null) {
-                        if (getPlugin().hasPermission(player, "worldguard.override.potions")) {
-                            return;
-                        }
-                        player.sendMessage(ChatColor.RED + "Sorry, arrows with "
-                                + blockedEffect.getName() + " are presently disabled.");
-                    }
-                    event.setCancelled(true);
-                }
+        if (!(event.getOriginalEvent() instanceof EntityDamageByEntityEvent originalEvent)) {
+            return;
+        }
+        if (!Entities.isPotionArrow(originalEvent.getDamager())) {
+            return;
+        }
+
+        BukkitWorldConfiguration wcfg = getWorldConfig(event.getWorld());
+        PotionEffectType blockedEffect = null;
+        if (originalEvent.getDamager() instanceof SpectralArrow) {
+            if (wcfg.blockPotions.contains(PotionEffectType.GLOWING)) {
+                blockedEffect = PotionEffectType.GLOWING;
             }
+        } else if (originalEvent.getDamager() instanceof Arrow arrow) {
+            blockedEffect = getBlockedEffectByArrow(arrow, wcfg);
+        }
+        if (blockedEffect != null) {
+            Player player = event.getCause().getFirstPlayer();
+            if (player != null) {
+                if (getPlugin().hasPermission(player, "worldguard.override.potions")) {
+                    return;
+                }
+                player.sendMessage(ChatColor.RED + "Sorry, arrows with "
+                        + blockedEffect.getName() + " are presently disabled.");
+            }
+            event.setCancelled(true);
         }
     }
 
@@ -104,25 +115,20 @@ public class BlockedPotionsListener extends AbstractListener {
         if (!wcfg.blockPotions.isEmpty()) {
             PotionEffectType blockedEffect = null;
 
-            PotionMeta meta;
-            if (item.getItemMeta() instanceof PotionMeta) {
-                meta = ((PotionMeta) item.getItemMeta());
-            } else {
-                return; // ok...?
+            if (!(item.getItemMeta() instanceof PotionMeta meta)) {
+                return;
             }
 
             // Find the first blocked effect
-            PotionEffectType baseEffect = meta.getBasePotionData().getType().getEffectType();
-            if (wcfg.blockPotions.contains(baseEffect)) {
-                blockedEffect = baseEffect;
+            List<PotionEffect> effects = new ArrayList<>();
+            if (meta.getBasePotionType() != null) {
+                effects.addAll(meta.getBasePotionType().getPotionEffects());
             }
-
-            if (blockedEffect == null && meta.hasCustomEffects()) {
-                for (PotionEffect effect : meta.getCustomEffects()) {
-                    if (wcfg.blockPotions.contains(effect.getType())) {
-                        blockedEffect = effect.getType();
-                        break;
-                    }
+            effects.addAll(meta.getCustomEffects());
+            for (PotionEffect potionEffect : effects) {
+                if (wcfg.blockPotions.contains(potionEffect.getType())) {
+                    blockedEffect = potionEffect.getType();
+                    break;
                 }
             }
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -146,7 +146,6 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 
@@ -1087,9 +1086,9 @@ public class EventAbstractionListener extends AbstractListener {
     public void onLingeringApply(AreaEffectCloudApplyEvent event) {
         AreaEffectCloud entity = event.getEntity();
         List<PotionEffect> effects = new ArrayList<>();
-        PotionEffectType baseEffectType = entity.getBasePotionData().getType().getEffectType();
-        if (baseEffectType != null) {
-            effects.add(new PotionEffect(baseEffectType, 0, 0));
+        List<PotionEffect> baseEffectTypes = entity.getBasePotionType() == null ? null : entity.getBasePotionType().getPotionEffects();
+        if (baseEffectTypes != null) {
+            effects.addAll(baseEffectTypes);
         }
         if (entity.hasCustomEffects()) {
             effects.addAll(entity.getCustomEffects());
@@ -1174,7 +1173,7 @@ public class EventAbstractionListener extends AbstractListener {
 
         if (item != null && item.getType() == Material.END_CRYSTAL) { /*&& placed.getType() == Material.BEDROCK) {*/ // in vanilla you can only place them on bedrock but who knows what plugins will add
                                                                                                                         // may be overprotective as a result, but better than being underprotective
-            Events.fireToCancel(event, new SpawnEntityEvent(event, cause, placed.getLocation().add(0.5, 0, 0.5), EntityType.ENDER_CRYSTAL));
+            Events.fireToCancel(event, new SpawnEntityEvent(event, cause, placed.getLocation().add(0.5, 0, 0.5), EntityType.END_CRYSTAL));
             return;
         }
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
@@ -25,7 +25,6 @@ import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.session.MoveType;
 import com.sk89q.worldguard.session.Session;
-import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.AbstractHorse;
@@ -34,14 +33,13 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityMountEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.util.Vector;
-import org.spigotmc.event.entity.EntityMountEvent;
 
 public class PlayerMoveListener extends AbstractListener {
 
@@ -54,9 +52,6 @@ public class PlayerMoveListener extends AbstractListener {
         if (WorldGuard.getInstance().getPlatform().getGlobalStateManager().usePlayerMove) {
             PluginManager pm = getPlugin().getServer().getPluginManager();
             pm.registerEvents(this, getPlugin());
-            if (PaperLib.isSpigot()) {
-                pm.registerEvents(new EntityMountListener(), getPlugin());
-            }
         }
     }
 
@@ -152,16 +147,14 @@ public class PlayerMoveListener extends AbstractListener {
         session.uninitialize(localPlayer);
     }
 
-    private class EntityMountListener implements Listener {
-        @EventHandler
-        public void onEntityMount(EntityMountEvent event) {
-            Entity entity = event.getEntity();
-            if (entity instanceof Player) {
-                LocalPlayer player = getPlugin().wrapPlayer((Player) entity);
-                Session session = WorldGuard.getInstance().getPlatform().getSessionManager().get(player);
-                if (null != session.testMoveTo(player, BukkitAdapter.adapt(event.getMount().getLocation()), MoveType.EMBARK, true)) {
-                    event.setCancelled(true);
-                }
+    @EventHandler
+    public void onEntityMount(EntityMountEvent event) {
+        Entity entity = event.getEntity();
+        if (entity instanceof Player) {
+            LocalPlayer player = getPlugin().wrapPlayer((Player) entity);
+            Session session = WorldGuard.getInstance().getPlatform().getSessionManager().get(player);
+            if (null != session.testMoveTo(player, BukkitAdapter.adapt(event.getMount().getLocation()), MoveType.EMBARK, true)) {
+                event.setCancelled(true);
             }
         }
     }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionFlagsListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionFlagsListener.java
@@ -69,7 +69,7 @@ public class RegionFlagsListener extends AbstractListener {
             }
         }
 
-        if (event.getCause().find(EntityType.SNOWMAN) != null) {
+        if (event.getCause().find(EntityType.SNOW_GOLEM) != null) {
             event.filter(testState(query, Flags.SNOWMAN_TRAILS), false);
         }
 
@@ -100,7 +100,7 @@ public class RegionFlagsListener extends AbstractListener {
             event.filter(testState(query, Flags.ENDERDRAGON_BLOCK_DAMAGE), config.explosionFlagCancellation);
         }
 
-        if (event.getCause().find(EntityType.ENDER_CRYSTAL) != null) { // EnderCrystal
+        if (event.getCause().find(EntityType.END_CRYSTAL) != null) { // EnderCrystal
             event.filter(testState(query, Flags.OTHER_EXPLOSION), config.explosionFlagCancellation);
         }
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -218,7 +218,7 @@ public class RegionProtectionListener extends AbstractListener {
                 String what;
 
                 /* TNT */
-                if (event.getCause().find(EntityType.PRIMED_TNT, EntityType.MINECART_TNT) != null) {
+                if (event.getCause().find(EntityType.TNT, EntityType.TNT_MINECART) != null) {
                     canBreak = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.BLOCK_BREAK, Flags.TNT));
                     what = "use dynamite";
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -586,8 +586,8 @@ public class WorldGuardEntityListener extends AbstractListener {
                 event.setCancelled(true);
                 return;
             }
-        } else if (event.getEntityType() == EntityType.PRIMED_TNT
-                || event.getEntityType() == EntityType.MINECART_TNT) {
+        } else if (event.getEntityType() == EntityType.TNT
+                || event.getEntityType() == EntityType.TNT_MINECART) {
             if (wcfg.blockTNTExplosions) {
                 event.setCancelled(true);
                 return;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
@@ -127,8 +127,8 @@ public final class Entities {
      */
     public static boolean isMinecart(EntityType type) {
         return switch(type) {
-            case MINECART, MINECART_CHEST, MINECART_COMMAND, MINECART_FURNACE,
-                    MINECART_HOPPER, MINECART_MOB_SPAWNER, MINECART_TNT -> true;
+            case MINECART, CHEST_MINECART, COMMAND_BLOCK_MINECART, FURNACE_MINECART,
+                 HOPPER_MINECART, SPAWNER_MINECART, TNT_MINECART -> true;
             default -> false;
         };
     }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -56,7 +56,6 @@ public final class Materials {
         if (tag == null) return;
         tag.getValues().forEach(mat -> MATERIAL_FLAGS.put(mat, value));
     }
-    private static Tag<Material> SIGNS_TAG = Tag.SIGNS;
 
     static {
         ENTITY_ITEMS.put(EntityType.PAINTING, Material.PAINTING);
@@ -64,22 +63,22 @@ public final class Materials {
         ENTITY_ITEMS.put(EntityType.SNOWBALL, Material.SNOWBALL);
         ENTITY_ITEMS.put(EntityType.FIREBALL, Material.FIRE_CHARGE);
         ENTITY_ITEMS.put(EntityType.ENDER_PEARL, Material.ENDER_PEARL);
-        ENTITY_ITEMS.put(EntityType.THROWN_EXP_BOTTLE, Material.EXPERIENCE_BOTTLE);
+        ENTITY_ITEMS.put(EntityType.EXPERIENCE_BOTTLE, Material.EXPERIENCE_BOTTLE);
         ENTITY_ITEMS.put(EntityType.ITEM_FRAME, Material.ITEM_FRAME);
         ENTITY_ITEMS.put(EntityType.GLOW_ITEM_FRAME, Material.GLOW_ITEM_FRAME);
-        ENTITY_ITEMS.put(EntityType.PRIMED_TNT, Material.TNT);
-        ENTITY_ITEMS.put(EntityType.FIREWORK, Material.FIREWORK_ROCKET);
-        ENTITY_ITEMS.put(EntityType.MINECART_COMMAND, Material.COMMAND_BLOCK_MINECART);
+        ENTITY_ITEMS.put(EntityType.TNT, Material.TNT);
+        ENTITY_ITEMS.put(EntityType.FIREWORK_ROCKET, Material.FIREWORK_ROCKET);
+        ENTITY_ITEMS.put(EntityType.COMMAND_BLOCK_MINECART, Material.COMMAND_BLOCK_MINECART);
         ENTITY_ITEMS.put(EntityType.BOAT, Material.OAK_BOAT);
         ENTITY_ITEMS.put(EntityType.MINECART, Material.MINECART);
-        ENTITY_ITEMS.put(EntityType.MINECART_CHEST, Material.CHEST_MINECART);
-        ENTITY_ITEMS.put(EntityType.MINECART_FURNACE, Material.FURNACE_MINECART);
-        ENTITY_ITEMS.put(EntityType.MINECART_TNT, Material.TNT_MINECART);
-        ENTITY_ITEMS.put(EntityType.MINECART_HOPPER, Material.HOPPER_MINECART);
-        ENTITY_ITEMS.put(EntityType.SPLASH_POTION, Material.POTION);
+        ENTITY_ITEMS.put(EntityType.CHEST_MINECART, Material.CHEST_MINECART);
+        ENTITY_ITEMS.put(EntityType.FURNACE_MINECART, Material.FURNACE_MINECART);
+        ENTITY_ITEMS.put(EntityType.TNT_MINECART, Material.TNT_MINECART);
+        ENTITY_ITEMS.put(EntityType.HOPPER_MINECART, Material.HOPPER_MINECART);
+        ENTITY_ITEMS.put(EntityType.POTION, Material.POTION);
         ENTITY_ITEMS.put(EntityType.EGG, Material.EGG);
         ENTITY_ITEMS.put(EntityType.ARMOR_STAND, Material.ARMOR_STAND);
-        ENTITY_ITEMS.put(EntityType.ENDER_CRYSTAL, Material.END_CRYSTAL);
+        ENTITY_ITEMS.put(EntityType.END_CRYSTAL, Material.END_CRYSTAL);
 
         MATERIAL_FLAGS.put(Material.AIR, 0);
         MATERIAL_FLAGS.put(Material.STONE, 0);
@@ -642,7 +641,7 @@ public final class Materials {
         MATERIAL_FLAGS.put(Material.PUFFERFISH_BUCKET, 0);
         MATERIAL_FLAGS.put(Material.SALMON, 0);
         MATERIAL_FLAGS.put(Material.SALMON_BUCKET, 0);
-        MATERIAL_FLAGS.put(Material.SCUTE, 0);
+        MATERIAL_FLAGS.put(Material.TURTLE_SCUTE, 0);
         MATERIAL_FLAGS.put(Material.SPLASH_POTION, 0);
         MATERIAL_FLAGS.put(Material.TURTLE_HELMET, 0);
         MATERIAL_FLAGS.put(Material.TRIDENT, 0);
@@ -821,31 +820,28 @@ public final class Materials {
         MATERIAL_FLAGS.put(Material.ECHO_SHARD, 0);
         MATERIAL_FLAGS.put(Material.REINFORCED_DEEPSLATE, 0);
 
-        // 1.20
-        try {
-            SIGNS_TAG = Tag.ALL_SIGNS;
+        MATERIAL_FLAGS.put(Material.BAMBOO_MOSAIC, 0);
+        MATERIAL_FLAGS.put(Material.BAMBOO_BLOCK, 0);
+        MATERIAL_FLAGS.put(Material.STRIPPED_BAMBOO_BLOCK, 0);
+        MATERIAL_FLAGS.put(Material.SUSPICIOUS_SAND, 0);
+        MATERIAL_FLAGS.put(Material.SUSPICIOUS_GRAVEL, 0);
+        MATERIAL_FLAGS.put(Material.PITCHER_PLANT, 0);
+        MATERIAL_FLAGS.put(Material.CHISELED_BOOKSHELF, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.DECORATED_POT, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.BRUSH, 0);
+        MATERIAL_FLAGS.put(Material.SNIFFER_EGG, 0);
+        MATERIAL_FLAGS.put(Material.CALIBRATED_SCULK_SENSOR, 0);
+        MATERIAL_FLAGS.put(Material.PIGLIN_HEAD, 0);
+        MATERIAL_FLAGS.put(Material.PIGLIN_WALL_HEAD, 0);
+        MATERIAL_FLAGS.put(Material.TORCHFLOWER_SEEDS, 0);
+        MATERIAL_FLAGS.put(Material.TORCHFLOWER_CROP, 0);
+        MATERIAL_FLAGS.put(Material.PITCHER_CROP, 0);
+        MATERIAL_FLAGS.put(Material.PINK_PETALS, 0);
+        MATERIAL_FLAGS.put(Material.PITCHER_POD, 0);
+        MATERIAL_FLAGS.put(Material.NETHERITE_UPGRADE_SMITHING_TEMPLATE, 0);
 
-            MATERIAL_FLAGS.put(Material.BAMBOO_MOSAIC, 0);
-            MATERIAL_FLAGS.put(Material.BAMBOO_BLOCK, 0);
-            MATERIAL_FLAGS.put(Material.STRIPPED_BAMBOO_BLOCK, 0);
-            MATERIAL_FLAGS.put(Material.SUSPICIOUS_SAND, 0);
-            MATERIAL_FLAGS.put(Material.SUSPICIOUS_GRAVEL, 0);
-            MATERIAL_FLAGS.put(Material.PITCHER_PLANT, 0);
-            MATERIAL_FLAGS.put(Material.CHISELED_BOOKSHELF, MODIFIED_ON_RIGHT);
-            MATERIAL_FLAGS.put(Material.DECORATED_POT, MODIFIED_ON_RIGHT);
-            MATERIAL_FLAGS.put(Material.BRUSH, 0);
-            MATERIAL_FLAGS.put(Material.SNIFFER_EGG, 0);
-            MATERIAL_FLAGS.put(Material.CALIBRATED_SCULK_SENSOR, 0);
-            MATERIAL_FLAGS.put(Material.PIGLIN_HEAD, 0);
-            MATERIAL_FLAGS.put(Material.PIGLIN_WALL_HEAD, 0);
-            MATERIAL_FLAGS.put(Material.TORCHFLOWER_SEEDS, 0);
-            MATERIAL_FLAGS.put(Material.TORCHFLOWER_CROP, 0);
-            MATERIAL_FLAGS.put(Material.PITCHER_CROP, 0);
-            MATERIAL_FLAGS.put(Material.PINK_PETALS, 0);
-            MATERIAL_FLAGS.put(Material.PITCHER_POD, 0);
-            MATERIAL_FLAGS.put(Material.NETHERITE_UPGRADE_SMITHING_TEMPLATE, 0);
-        } catch (NoSuchFieldError ignored) {
-        }
+        MATERIAL_FLAGS.put(Material.ARMADILLO_SCUTE, 0);
+        MATERIAL_FLAGS.put(Material.WOLF_ARMOR, 0);
 
         // Generated via tag
         putMaterialTag(Tag.WOODEN_DOORS, MODIFIED_ON_RIGHT);
@@ -865,7 +861,7 @@ public final class Materials {
         putMaterialTag(Tag.BUTTONS, MODIFIED_ON_RIGHT);
         putMaterialTag(Tag.FLOWER_POTS, MODIFIED_ON_RIGHT);
         putMaterialTag(Tag.WALLS, 0);
-        putMaterialTag(SIGNS_TAG, 0);
+        putMaterialTag(Tag.ALL_SIGNS, 0);
         putMaterialTag(Tag.SMALL_FLOWERS, 0);
         putMaterialTag(Tag.BEDS, MODIFIED_ON_RIGHT);
         putMaterialTag(Tag.ITEMS_MUSIC_DISCS, 0);
@@ -884,12 +880,10 @@ public final class Materials {
         putMaterialTag(Tag.CANDLES, MODIFIED_ON_RIGHT);
         putMaterialTag(Tag.CANDLE_CAKES, MODIFIED_ON_RIGHT);
         putMaterialTag(Tag.CAULDRONS, MODIFIED_ON_RIGHT);
-        try {
-            // 1.20
-            putMaterialTag(Tag.ITEMS_TRIM_TEMPLATES, 0);
-            putMaterialTag(Tag.ITEMS_DECORATED_POT_SHERDS, 0);
-        } catch (NoSuchFieldError ignored) {
-        }
+
+        // 1.20
+        putMaterialTag(Tag.ITEMS_TRIM_TEMPLATES, 0);
+        putMaterialTag(Tag.ITEMS_DECORATED_POT_SHERDS, 0);
 
         Stream.concat(Stream.concat(
                 Tag.CORAL_BLOCKS.getValues().stream(),
@@ -915,14 +909,14 @@ public final class Materials {
         }
 
 //        DAMAGE_EFFECTS.add(PotionEffectType.SPEED);
-        DAMAGE_EFFECTS.add(PotionEffectType.SLOW);
+        DAMAGE_EFFECTS.add(PotionEffectType.SLOWNESS);
 //        DAMAGE_EFFECTS.add(PotionEffectType.FAST_DIGGING);
-        DAMAGE_EFFECTS.add(PotionEffectType.SLOW_DIGGING);
+        DAMAGE_EFFECTS.add(PotionEffectType.MINING_FATIGUE);
 //        DAMAGE_EFFECTS.add(PotionEffectType.INCREASE_DAMAGE);
 //        DAMAGE_EFFECTS.add(PotionEffectType.HEAL);
-        DAMAGE_EFFECTS.add(PotionEffectType.HARM);
+        DAMAGE_EFFECTS.add(PotionEffectType.INSTANT_DAMAGE);
 //        DAMAGE_EFFECTS.add(PotionEffectType.JUMP);
-        DAMAGE_EFFECTS.add(PotionEffectType.CONFUSION);
+        DAMAGE_EFFECTS.add(PotionEffectType.NAUSEA);
 //        DAMAGE_EFFECTS.add(PotionEffectType.REGENERATION);
 //        DAMAGE_EFFECTS.add(PotionEffectType.DAMAGE_RESISTANCE);
 //        DAMAGE_EFFECTS.add(PotionEffectType.FIRE_RESISTANCE);
@@ -988,13 +982,11 @@ public final class Materials {
      * @return the block material
      */
     public static Material getBucketBlockMaterial(Material type) {
-        switch (type) {
-            case LAVA_BUCKET:
-                return Material.LAVA;
-            case WATER_BUCKET:
-            default:
-                return Material.WATER;
-        }
+        return switch (type) {
+            case LAVA_BUCKET -> Material.LAVA;
+            case WATER_BUCKET -> Material.WATER;
+            default -> Material.WATER;
+        };
     }
 
     /**
@@ -1146,6 +1138,7 @@ public final class Materials {
     public static EntityType getEntitySpawnEgg(Material material) {
         return switch (material) {
             case ALLAY_SPAWN_EGG -> EntityType.ALLAY;
+            case ARMADILLO_SPAWN_EGG -> EntityType.ARMADILLO;
             case AXOLOTL_SPAWN_EGG -> EntityType.AXOLOTL;
             case SPIDER_SPAWN_EGG -> EntityType.SPIDER;
             case BAT_SPAWN_EGG -> EntityType.BAT;
@@ -1178,7 +1171,7 @@ public final class Materials {
             case IRON_GOLEM_SPAWN_EGG -> EntityType.IRON_GOLEM;
             case LLAMA_SPAWN_EGG -> EntityType.LLAMA;
             case MAGMA_CUBE_SPAWN_EGG -> EntityType.MAGMA_CUBE;
-            case MOOSHROOM_SPAWN_EGG -> EntityType.MUSHROOM_COW;
+            case MOOSHROOM_SPAWN_EGG -> EntityType.MOOSHROOM;
             case MULE_SPAWN_EGG -> EntityType.MULE;
             case OCELOT_SPAWN_EGG -> EntityType.OCELOT;
             case PANDA_SPAWN_EGG -> EntityType.PANDA;
@@ -1199,7 +1192,7 @@ public final class Materials {
             case SKELETON_SPAWN_EGG -> EntityType.SKELETON;
             case SLIME_SPAWN_EGG -> EntityType.SLIME;
             case SNIFFER_SPAWN_EGG -> EntityType.SNIFFER;
-            case SNOW_GOLEM_SPAWN_EGG -> EntityType.SNOWMAN;
+            case SNOW_GOLEM_SPAWN_EGG -> EntityType.SNOW_GOLEM;
             case SQUID_SPAWN_EGG -> EntityType.SQUID;
             case STRAY_SPAWN_EGG -> EntityType.STRAY;
             case STRIDER_SPAWN_EGG -> EntityType.STRIDER;
@@ -1457,9 +1450,9 @@ public final class Materials {
             case YELLOW_DYE:
             case GLOW_INK_SAC:
             case INK_SAC:
-                return SIGNS_TAG.isTagged(targetMaterial);
+                return Tag.ALL_SIGNS.isTagged(targetMaterial);
             case HONEYCOMB:
-                return isUnwaxedCopper(targetMaterial) || SIGNS_TAG.isTagged(targetMaterial);
+                return isUnwaxedCopper(targetMaterial) || Tag.ALL_SIGNS.isTagged(targetMaterial);
             case BRUSH:
                 return switch (targetMaterial) {
                     case SUSPICIOUS_GRAVEL, SUSPICIOUS_SAND -> true;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/blacklist/logger/DatabaseHandler.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/blacklist/logger/DatabaseHandler.java
@@ -95,9 +95,9 @@ public class DatabaseHandler implements LoggerHandler {
             stmt.setString(1, eventType.name());
             stmt.setString(2, worldName);
             stmt.setString(3, player != null ? player.getName() : "");
-            stmt.setInt(4, pos.getBlockX());
-            stmt.setInt(5, pos.getBlockY());
-            stmt.setInt(6, pos.getBlockZ());
+            stmt.setInt(4, pos.x());
+            stmt.setInt(5, pos.y());
+            stmt.setInt(6, pos.z());
             stmt.setString(7, item);
             stmt.setInt(8, (int)(System.currentTimeMillis() / 1000));
             stmt.setString(9, comment);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/blacklist/logger/FileHandler.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/blacklist/logger/FileHandler.java
@@ -221,7 +221,7 @@ public class FileHandler implements LoggerHandler {
      * @return The position's coordinates in human-readable form
      */
     private String getCoordinates(BlockVector3 pos) {
-        return "@" + pos.getBlockX() + "," + pos.getBlockY() + "," + pos.getBlockZ();
+        return "@" + pos.x() + "," + pos.y() + "," + pos.z();
     }
 
     private void logEvent(BlacklistEvent event, String text, Target target, BlockVector3 pos, String comment) {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/FlagHelperBox.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/FlagHelperBox.java
@@ -378,7 +378,7 @@ class FlagHelperBox extends PaginationBox {
         if (currVal == null) {
             currVal = getInheritedValue(region, flag);
         }
-        String display = currVal == null ? regName : currVal.getId();
+        String display = currVal == null ? regName : currVal.id();
         appendValueText(builder, flag, display, null);
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
@@ -308,8 +308,8 @@ class RegionCommandsBase {
         // Detect the type of region from WorldEdit
         if (selection instanceof Polygonal2DRegion) {
             Polygonal2DRegion polySel = (Polygonal2DRegion) selection;
-            int minY = polySel.getMinimumPoint().getBlockY();
-            int maxY = polySel.getMaximumPoint().getBlockY();
+            int minY = polySel.getMinimumPoint().y();
+            int maxY = polySel.getMaximumPoint().y();
             return new ProtectedPolygonalRegion(id, polySel.getPoints(), minY, maxY);
         } else if (selection instanceof CuboidRegion) {
             BlockVector3 min = selection.getMinimumPoint();
@@ -348,7 +348,7 @@ class RegionCommandsBase {
         if (region instanceof GlobalProtectedRegion) {
             return;
         }
-        int height = region.getMaximumPoint().getBlockY() - region.getMinimumPoint().getBlockY();
+        int height = region.getMaximumPoint().y() - region.getMinimumPoint().y();
         if (height <= 2) {
             sender.printDebug("(Warning: The height of the region was " + (height + 1) + " block(s).)");
         }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/EntityTypeFlag.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/EntityTypeFlag.java
@@ -57,6 +57,6 @@ public class EntityTypeFlag extends Flag<EntityType> {
 
     @Override
     public Object marshal(EntityType o) {
-        return o.getId();
+        return o.id();
     }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/GameModeTypeFlag.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/GameModeTypeFlag.java
@@ -57,6 +57,6 @@ public class GameModeTypeFlag extends Flag<GameMode> {
 
     @Override
     public Object marshal(GameMode o) {
-        return o.getId();
+        return o.id();
     }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/LocationFlag.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/LocationFlag.java
@@ -137,9 +137,9 @@ public class LocationFlag extends Flag<Location> {
                 return null;
             }
         }
-        vec.put("x", position.getX());
-        vec.put("y", position.getY());
-        vec.put("z", position.getZ());
+        vec.put("x", position.x());
+        vec.put("y", position.y());
+        vec.put("z", position.z());
         vec.put("yaw", o.getYaw());
         vec.put("pitch", o.getPitch());
         return vec;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/RegistryFlag.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/RegistryFlag.java
@@ -61,6 +61,6 @@ public class RegistryFlag<T extends Keyed> extends Flag<T> {
 
     @Override
     public Object marshal(T o) {
-        return o.getId();
+        return o.id();
     }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/VectorFlag.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/VectorFlag.java
@@ -82,9 +82,9 @@ public class VectorFlag extends Flag<Vector3> {
     @Override
     public Object marshal(Vector3 o) {
         Map<String, Object> vec = new HashMap<>();
-        vec.put("x", o.getX());
-        vec.put("y", o.getY());
-        vec.put("z", o.getZ());
+        vec.put("x", o.x());
+        vec.put("y", o.y());
+        vec.put("z", o.z());
         return vec;
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/WeatherTypeFlag.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/WeatherTypeFlag.java
@@ -57,6 +57,6 @@ public class WeatherTypeFlag extends Flag<WeatherType> {
 
     @Override
     public Object marshal(WeatherType o) {
-        return o.getId();
+        return o.id();
     }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/index/ChunkHashTable.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/index/ChunkHashTable.java
@@ -93,10 +93,10 @@ public class ChunkHashTable implements ConcurrentRegionIndex {
     private ChunkState get(BlockVector2 position, boolean create) {
         ChunkState state;
         synchronized (lock) {
-            state = states.get(position.getBlockX(), position.getBlockZ());
+            state = states.get(position.x(), position.z());
             if (state == null && create) {
                 state = new ChunkState(position);
-                states.put(position.getBlockX(), position.getBlockZ(), state);
+                states.put(position.x(), position.z(), state);
                 executor.submit(new EnumerateRegions(position));
             }
         }
@@ -130,7 +130,7 @@ public class ChunkHashTable implements ConcurrentRegionIndex {
             for (ChunkState state : previousStates.values()) {
                 BlockVector2 position = state.getPosition();
                 positions.add(position);
-                states.put(position.getBlockX(), position.getBlockZ(), new ChunkState(position));
+                states.put(position.x(), position.z(), new ChunkState(position));
             }
 
             if (!positions.isEmpty()) {
@@ -179,9 +179,9 @@ public class ChunkHashTable implements ConcurrentRegionIndex {
     public void forget(BlockVector2 chunkPosition) {
         checkNotNull(chunkPosition);
         synchronized (lock) {
-            states.remove(chunkPosition.getBlockX(), chunkPosition.getBlockZ());
+            states.remove(chunkPosition.x(), chunkPosition.z());
             ChunkState state = lastState;
-            if (state != null && state.getPosition().getBlockX() == chunkPosition.getBlockX() && state.getPosition().getBlockZ() == chunkPosition.getBlockZ()) {
+            if (state != null && state.getPosition().x() == chunkPosition.x() && state.getPosition().z() == chunkPosition.z()) {
                 lastState = null;
             }
         }
@@ -238,10 +238,10 @@ public class ChunkHashTable implements ConcurrentRegionIndex {
         checkNotNull(consumer);
 
         ChunkState state = lastState;
-        int chunkX = position.getBlockX() >> 4;
-        int chunkZ = position.getBlockZ() >> 4;
+        int chunkX = position.x() >> 4;
+        int chunkZ = position.z() >> 4;
 
-        if (state == null || state.getPosition().getBlockX() != chunkX || state.getPosition().getBlockZ() != chunkZ) {
+        if (state == null || state.getPosition().x() != chunkX || state.getPosition().z() != chunkZ) {
             state = get(BlockVector2.at(chunkX, chunkZ), false);
         }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/index/PriorityRTreeIndex.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/index/PriorityRTreeIndex.java
@@ -69,7 +69,7 @@ public class PriorityRTreeIndex extends HashMapIndex {
     @Override
     public void applyContaining(BlockVector3 position, Predicate<ProtectedRegion> consumer) {
         Set<ProtectedRegion> seen = new HashSet<>();
-        MBR pointMBR = new SimpleMBR(position.getX(), position.getX(), position.getY(), position.getY(), position.getZ(), position.getZ());
+        MBR pointMBR = new SimpleMBR(position.x(), position.x(), position.y(), position.y(), position.z(), position.z());
 
         for (ProtectedRegion region : tree.find(pointMBR)) {
             if (region.contains(position) && !seen.contains(region)) {
@@ -87,7 +87,7 @@ public class PriorityRTreeIndex extends HashMapIndex {
         BlockVector3 max = region.getMaximumPoint().ceil();
 
         Set<ProtectedRegion> candidates = new HashSet<>();
-        MBR pointMBR = new SimpleMBR(min.getX(), max.getX(), min.getY(), max.getY(), min.getZ(), max.getZ());
+        MBR pointMBR = new SimpleMBR(min.x(), max.x(), min.y(), max.y(), min.z(), max.z());
 
         for (ProtectedRegion found : tree.find(pointMBR)) {
             candidates.add(found);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/migration/WorldHeightMigration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/migration/WorldHeightMigration.java
@@ -84,8 +84,8 @@ public class WorldHeightMigration extends AbstractMigration {
             if (min == 0 && max == 255) return;
         }
         for (ProtectedRegion region : regions) {
-            if (region.getMinimumPoint().getBlockY() <= 0
-                    && region.getMaximumPoint().getBlockY() >= 255) {
+            if (region.getMinimumPoint().y() <= 0
+                    && region.getMaximumPoint().y() >= 255) {
                 expand(region, min, max);
                 changed++;
             }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/file/YamlRegionFile.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/file/YamlRegionFile.java
@@ -214,14 +214,14 @@ public class YamlRegionFile implements RegionDatabase {
             } else if (region instanceof ProtectedPolygonalRegion) {
                 ProtectedPolygonalRegion poly = (ProtectedPolygonalRegion) region;
                 node.setProperty("type", "poly2d");
-                node.setProperty("min-y", poly.getMinimumPoint().getBlockY());
-                node.setProperty("max-y", poly.getMaximumPoint().getBlockY());
+                node.setProperty("min-y", poly.getMinimumPoint().y());
+                node.setProperty("max-y", poly.getMaximumPoint().y());
 
                 List<Map<String, Object>> points = new ArrayList<>();
                 for (BlockVector2 point : poly.getPoints()) {
                     Map<String, Object> data = new HashMap<>();
-                    data.put("x", point.getBlockX());
-                    data.put("z", point.getBlockZ());
+                    data.put("x", point.x());
+                    data.put("z", point.z());
                     points.add(data);
                 }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/RegionInserter.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/RegionInserter.java
@@ -113,12 +113,12 @@ class RegionInserter {
                     BlockVector3 max = region.getMaximumPoint();
 
                     stmt.setString(1, region.getId());
-                    stmt.setInt(2, min.getBlockZ());
-                    stmt.setInt(3, min.getBlockY());
-                    stmt.setInt(4, min.getBlockX());
-                    stmt.setInt(5, max.getBlockZ());
-                    stmt.setInt(6, max.getBlockY());
-                    stmt.setInt(7, max.getBlockX());
+                    stmt.setInt(2, min.z());
+                    stmt.setInt(3, min.y());
+                    stmt.setInt(4, min.x());
+                    stmt.setInt(5, max.z());
+                    stmt.setInt(6, max.y());
+                    stmt.setInt(7, max.x());
                     stmt.addBatch();
                 }
 
@@ -141,8 +141,8 @@ class RegionInserter {
             for (List<ProtectedPolygonalRegion> partition : Lists.partition(polygons, StatementBatch.MAX_BATCH_SIZE)) {
                 for (ProtectedPolygonalRegion region : partition) {
                     stmt.setString(1, region.getId());
-                    stmt.setInt(2, region.getMaximumPoint().getBlockY());
-                    stmt.setInt(3, region.getMinimumPoint().getBlockY());
+                    stmt.setInt(2, region.getMaximumPoint().y());
+                    stmt.setInt(3, region.getMinimumPoint().y());
                     stmt.addBatch();
                 }
 
@@ -167,8 +167,8 @@ class RegionInserter {
             for (ProtectedPolygonalRegion region : polygons) {
                 for (BlockVector2 point : region.getPoints()) {
                     stmt.setString(1, region.getId());
-                    stmt.setInt(2, point.getBlockZ());
-                    stmt.setInt(3, point.getBlockX());
+                    stmt.setInt(2, point.z());
+                    stmt.setInt(3, point.x());
                     batch.addBatch();
                 }
             }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
@@ -69,7 +69,7 @@ public class GlobalProtectedRegion extends ProtectedRegion {
     public List<BlockVector2> getPoints() {
         // This doesn't make sense
         List<BlockVector2> pts = new ArrayList<>();
-        pts.add(BlockVector2.at(min.getBlockX(), min.getBlockZ()));
+        pts.add(BlockVector2.at(min.x(), min.z()));
         return pts;
     }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
@@ -113,10 +113,10 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
     @Override
     public List<BlockVector2> getPoints() {
         List<BlockVector2> pts = new ArrayList<>();
-        int x1 = min.getBlockX();
-        int x2 = max.getBlockX();
-        int z1 = min.getBlockZ();
-        int z2 = max.getBlockZ();
+        int x1 = min.x();
+        int x2 = max.x();
+        int z1 = min.z();
+        int z2 = max.z();
 
         pts.add(BlockVector2.at(x1, z1));
         pts.add(BlockVector2.at(x2, z1));
@@ -128,12 +128,12 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
 
     @Override
     public boolean contains(BlockVector3 pt) {
-        final double x = pt.getX();
-        final double y = pt.getY();
-        final double z = pt.getZ();
-        return x >= min.getBlockX() && x < max.getBlockX() + 1
-                && y >= min.getBlockY() && y < max.getBlockY() + 1
-                && z >= min.getBlockZ() && z < max.getBlockZ() + 1;
+        final double x = pt.x();
+        final double y = pt.y();
+        final double z = pt.z();
+        return x >= min.x() && x < max.x() + 1
+                && y >= min.y() && y < max.y() + 1
+                && z >= min.z() && z < max.z() + 1;
     }
 
     @Override
@@ -143,10 +143,10 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
 
     @Override
     Area toArea() {
-        int x = getMinimumPoint().getBlockX();
-        int z = getMinimumPoint().getBlockZ();
-        int width = getMaximumPoint().getBlockX() - x + 1;
-        int height = getMaximumPoint().getBlockZ() - z + 1;
+        int x = getMinimumPoint().x();
+        int z = getMinimumPoint().z();
+        int width = getMaximumPoint().x() - x + 1;
+        int height = getMaximumPoint().z() - z + 1;
         return new Area(new Rectangle(x, z, width, height));
     }
 
@@ -161,9 +161,9 @@ public class ProtectedCuboidRegion extends ProtectedRegion {
 
     @Override
     public int volume() {
-        int xLength = max.getBlockX() - min.getBlockX() + 1;
-        int yLength = max.getBlockY() - min.getBlockY() + 1;
-        int zLength = max.getBlockZ() - min.getBlockZ() + 1;
+        int xLength = max.x() - min.x() + 1;
+        int yLength = max.y() - min.y() + 1;
+        int zLength = max.z() - min.z() + 1;
 
         try {
             long v = MathUtils.checkedMultiply(xLength, yLength);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -65,8 +65,8 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
         ImmutableList<BlockVector2> immutablePoints = ImmutableList.copyOf(points);
         setMinMaxPoints(immutablePoints, minY, maxY);
         this.points = immutablePoints;
-        this.minY = min.getBlockY();
-        this.maxY = max.getBlockY();
+        this.minY = min.y();
+        this.maxY = max.y();
     }
 
     /**
@@ -82,7 +82,7 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
         List<BlockVector3> points = new ArrayList<>();
         int y = minY;
         for (BlockVector2 point2D : points2D) {
-            points.add(BlockVector3.at(point2D.getBlockX(), y, point2D.getBlockZ()));
+            points.add(BlockVector3.at(point2D.x(), y, point2D.z()));
             y = maxY;
         }
         setMinMaxPoints(points);
@@ -102,15 +102,15 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
     public boolean contains(BlockVector3 position) {
         checkNotNull(position);
 
-        int targetX = position.getBlockX(); // Width
-        int targetY = position.getBlockY(); // Height
-        int targetZ = position.getBlockZ(); // Depth
+        int targetX = position.x(); // Width
+        int targetY = position.y(); // Height
+        int targetZ = position.z(); // Depth
 
         if (targetY < minY || targetY > maxY) {
             return false;
         }
         //Quick and dirty check.
-        if (targetX < min.getBlockX() || targetX > max.getBlockX() || targetZ < min.getBlockZ() || targetZ > max.getBlockZ()) {
+        if (targetX < min.x() || targetX > max.x() || targetZ < min.z() || targetZ > max.z()) {
             return false;
         }
         boolean inside = false;
@@ -122,12 +122,12 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
         long crossproduct;
         int i;
 
-        xOld = points.get(npoints - 1).getBlockX();
-        zOld = points.get(npoints - 1).getBlockZ();
+        xOld = points.get(npoints - 1).x();
+        zOld = points.get(npoints - 1).z();
 
         for (i = 0; i < npoints; i++) {
-            xNew = points.get(i).getBlockX();
-            zNew = points.get(i).getBlockZ();
+            xNew = points.get(i).x();
+            zNew = points.get(i).z();
             //Check for corner
             if (xNew == targetX && zNew == targetZ) {
                 return true;
@@ -173,8 +173,8 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
 
         int i = 0;
         for (BlockVector2 point : points) {
-            xCoords[i] = point.getBlockX();
-            yCoords[i] = point.getBlockZ();
+            xCoords[i] = point.x();
+            yCoords[i] = point.z();
             i++;
         }
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
@@ -92,17 +92,17 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
      * @param points the points to set with at least one entry
      */
     protected void setMinMaxPoints(List<BlockVector3> points) {
-        int minX = points.get(0).getBlockX();
-        int minY = points.get(0).getBlockY();
-        int minZ = points.get(0).getBlockZ();
+        int minX = points.get(0).x();
+        int minY = points.get(0).y();
+        int minZ = points.get(0).z();
         int maxX = minX;
         int maxY = minY;
         int maxZ = minZ;
 
         for (BlockVector3 v : points) {
-            int x = v.getBlockX();
-            int y = v.getBlockY();
-            int z = v.getBlockZ();
+            int x = v.x();
+            int y = v.y();
+            int z = v.z();
 
             if (x < minX) minX = x;
             if (y < minY) minY = y;
@@ -514,7 +514,7 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
      */
     public boolean contains(BlockVector2 position) {
         checkNotNull(position);
-        return contains(BlockVector3.at(position.getBlockX(), min.getBlockY(), position.getBlockZ()));
+        return contains(BlockVector3.at(position.x(), min.y(), position.z()));
     }
 
     /**
@@ -607,16 +607,16 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
         BlockVector3 rMaxPoint = region.getMaximumPoint();
         BlockVector3 min = getMinimumPoint();
 
-        if (rMaxPoint.getBlockX() < min.getBlockX()) return false;
-        if (rMaxPoint.getBlockY() < min.getBlockY()) return false;
-        if (rMaxPoint.getBlockZ() < min.getBlockZ()) return false;
+        if (rMaxPoint.x() < min.x()) return false;
+        if (rMaxPoint.y() < min.y()) return false;
+        if (rMaxPoint.z() < min.z()) return false;
 
         BlockVector3 rMinPoint = region.getMinimumPoint();
         BlockVector3 max = getMaximumPoint();
 
-        if (rMinPoint.getBlockX() > max.getBlockX()) return false;
-        if (rMinPoint.getBlockY() > max.getBlockY()) return false;
-        if (rMinPoint.getBlockZ() > max.getBlockZ()) return false;
+        if (rMinPoint.x() > max.x()) return false;
+        if (rMinPoint.y() > max.y()) return false;
+        if (rMinPoint.z() > max.z()) return false;
 
         return true;
     }
@@ -636,16 +636,16 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
             for (BlockVector2 aPts2 : pts2) {
 
                 Line2D line1 = new Line2D.Double(
-                        lastPt1.getBlockX(),
-                        lastPt1.getBlockZ(),
-                        aPts1.getBlockX(),
-                        aPts1.getBlockZ());
+                        lastPt1.x(),
+                        lastPt1.z(),
+                        aPts1.x(),
+                        aPts1.z());
 
                 if (line1.intersectsLine(
-                        lastPt2.getBlockX(),
-                        lastPt2.getBlockZ(),
-                        aPts2.getBlockX(),
-                        aPts2.getBlockZ())) {
+                        lastPt2.x(),
+                        lastPt2.z(),
+                        aPts2.x(),
+                        aPts2.z())) {
                     return true;
                 }
                 lastPt2 = aPts2;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegionMBRConverter.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegionMBRConverter.java
@@ -30,27 +30,21 @@ public class ProtectedRegionMBRConverter implements MBRConverter<ProtectedRegion
 
     @Override
     public double getMax(int dimension, ProtectedRegion region) {
-        switch (dimension) {
-            case 0:
-                return region.getMaximumPoint().getBlockX();
-            case 1:
-                return region.getMaximumPoint().getBlockY();
-            case 2:
-                return region.getMaximumPoint().getBlockZ();
-        }
-        return 0;
+        return switch (dimension) {
+            case 0 -> region.getMaximumPoint().x();
+            case 1 -> region.getMaximumPoint().y();
+            case 2 -> region.getMaximumPoint().z();
+            default -> 0;
+        };
     }
 
     @Override
     public double getMin(int dimension, ProtectedRegion region) {
-        switch (dimension) {
-            case 0:
-                return region.getMinimumPoint().getBlockX();
-            case 1:
-                return region.getMinimumPoint().getBlockY();
-            case 2:
-                return region.getMinimumPoint().getBlockZ();
-        }
-        return 0;
+        return switch (dimension) {
+            case 0 -> region.getMinimumPoint().x();
+            case 1 -> region.getMinimumPoint().y();
+            case 2 -> region.getMinimumPoint().z();
+            default -> 0;
+        };
     }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/util/WorldEditRegionConverter.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/util/WorldEditRegionConverter.java
@@ -50,7 +50,7 @@ public final class WorldEditRegionConverter {
         }
         if (region instanceof ProtectedPolygonalRegion) {
             return new Polygonal2DRegion(null, region.getPoints(),
-                    region.getMinimumPoint().getY(), region.getMaximumPoint().getY());
+                    region.getMinimumPoint().y(), region.getMaximumPoint().y());
         }
         return null;
     }
@@ -68,7 +68,7 @@ public final class WorldEditRegionConverter {
         }
         if (region instanceof ProtectedPolygonalRegion) {
             return new Polygonal2DRegionSelector(null, region.getPoints(),
-                    region.getMinimumPoint().getY(), region.getMaximumPoint().getY());
+                    region.getMinimumPoint().y(), region.getMaximumPoint().y());
         }
         return null;
     }


### PR DESCRIPTION
This PR adds the support for Minecraft 1.20.5 to WorldGuard:

* Updated build dependencies to support JDK21
* Update required JDK to 21
* Drop support for Minecraft 1.20-1.20.4
* Requires WorldEdit 7.3.0
  * Fix multiple deprecation warnings
* Fix breaking API changes

ToDos:

- [ ] Wait for 1.20.6