### PR TITLE
Fix fire placement by blocks when fire-spread is set to deny

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -173,7 +173,7 @@ public class RegionProtectionListener extends AbstractListener {
             /* Flint and steel, fire charge, etc. */
             if (Materials.isFire(type)) {
                 Block block = event.getCause().getFirstBlock();
-                boolean fire = block != null && Materials.isFire(type);
+                boolean fire = block != null && Materials.isFire(block.getType());
                 boolean lava = block != null && Materials.isLava(block.getType());
                 List<StateFlag> flags = new ArrayList<>();
                 flags.add(Flags.BLOCK_PLACE);


### PR DESCRIPTION
Fixes #2070
This changes the logic back to what it was before bffe5e7
Right now whenever any block is the cause of a `PlaceBlockEvent` and `fire-spread` is set to deny the event gets cancelled. This results in issues like #2070 where a dispenser is unable to place fire to light a portal, effectively only allowing entities to place fire when the flag is set
This is because WorldGuard checks if the resulting block (which when placing fire is always fire) is fire, instead of the block actually placing the fire (the dispenser in this case)

This might cause issues if the block that caused the event in case of fire-spread isn't properly set as fire due to some bukkit bug. But we also check & block fire spread in https://github.com/EngineHub/WorldGuard/blob/master/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java#L249 if high-frequency-flags are enabled, so I don't see that as a big issue
