### PR TITLE
Fix checking bypass on initialize

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldguard.session;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -67,10 +68,9 @@ public abstract class AbstractSessionManager implements SessionManager {
             .expireAfterWrite(2, TimeUnit.SECONDS)
             .build(CacheLoader.from(tuple -> BYPASS_PERMISSION_TEST.test(tuple.getWorld(), tuple.getPlayer())));
 
-    private final LoadingCache<CacheKey, Session> sessions = CacheBuilder.newBuilder()
+    private final Cache<CacheKey, Session> sessions = CacheBuilder.newBuilder()
             .expireAfterAccess(SESSION_LIFETIME, TimeUnit.MINUTES)
-            .build(CacheLoader.from(key ->
-                    createSession(key.playerRef.get())));
+            .build();
 
     private boolean hasCustom = false;
     private List<Handler.Factory<? extends Handler>> handlers = new LinkedList<>();
@@ -152,7 +152,7 @@ public abstract class AbstractSessionManager implements SessionManager {
     @Override
     public void resetState(LocalPlayer player) {
         checkNotNull(player, "player");
-        @Nullable Session session = sessions.getIfPresent(new CacheKey(player));
+        @Nullable Session session = getIfPresentInternal(new CacheKey(player));
         if (session != null) {
             session.resetState(player);
         }
@@ -161,22 +161,30 @@ public abstract class AbstractSessionManager implements SessionManager {
     @Override
     @Nullable
     public Session getIfPresent(LocalPlayer player) {
-        return sessions.getIfPresent(new CacheKey(player));
+        return getIfPresentInternal(new CacheKey(player));
+    }
+
+    private Session getIfPresentInternal(CacheKey cacheKey) {
+        @Nullable Session session = sessions.getIfPresent(cacheKey);
+        if (session != null) {
+            session.ensureInitialized(cacheKey.playerRef.get(), this::initializeSession);
+            return session;
+        }
+        return null;
     }
 
     @Override
     public Session get(LocalPlayer player) {
-        return sessions.getUnchecked(new CacheKey(player));
+        Session session = sessions.asMap().computeIfAbsent(new CacheKey(player), (k) -> new Session(this));
+        session.ensureInitialized(player, this::initializeSession);
+        return session;
     }
 
-    @Override
-    public Session createSession(LocalPlayer player) {
-        Session session = new Session(this);
+    private void initializeSession(Session session, LocalPlayer player) {
         for (Handler.Factory<? extends Handler> factory : handlers) {
             session.register(factory.create(session));
         }
         session.initialize(player);
-        return session;
     }
 
     protected static final class CacheKey {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
@@ -180,6 +180,11 @@ public abstract class AbstractSessionManager implements SessionManager {
         return session;
     }
 
+    @Override
+    public Session createSession(LocalPlayer player) {
+        return get(player);
+    }
+
     private void initializeSession(Session session, LocalPlayer player) {
         for (Handler.Factory<? extends Handler> factory : handlers) {
             session.register(factory.create(session));

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -52,6 +53,7 @@ public class Session {
     private Location lastValid;
     private Set<ProtectedRegion> lastRegionSet;
     private final AtomicBoolean needRefresh = new AtomicBoolean(false);
+    private boolean initialized;
 
     /**
      * Create a new session.
@@ -118,6 +120,14 @@ public class Session {
         for (Handler handler : handlers.values()) {
             handler.initialize(player, location, set);
         }
+    }
+
+    synchronized void ensureInitialized(LocalPlayer player, BiConsumer<Session, LocalPlayer> initializer) {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+        initializer.accept(this, player);
     }
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
@@ -91,14 +91,6 @@ public interface SessionManager {
     boolean unregisterHandler(Handler.Factory<? extends Handler> factory);
 
     /**
-     * Create a session for a player.
-     *
-     * @param player The player
-     * @return The new session
-     */
-    Session createSession(LocalPlayer player);
-
-    /**
      * Get a player's session, if one exists.
      *
      * @param player The player

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
@@ -91,6 +91,16 @@ public interface SessionManager {
     boolean unregisterHandler(Handler.Factory<? extends Handler> factory);
 
     /**
+     * Create a session for a player.
+     *
+     * @param player The player
+     * @return The new session
+     * @deprecated Use {@link SessionManager#get} instead
+     */
+    @Deprecated
+    Session createSession(LocalPlayer player);
+
+    /**
      * Get a player's session, if one exists.
      *
      * @param player The player


### PR DESCRIPTION
Fixed that checking bypass on handlers initialize would always return false. Not really sure if this is the best approach.

Also removed the `SessionManager#createSession` because it was making this a bit more complicated and its not really used.