### PR TITLE
Adds concrete powder/anvil to no-physics-config

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -192,6 +192,8 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
 
         noPhysicsGravel = getBoolean("physics.no-physics-gravel", false);
         noPhysicsSand = getBoolean("physics.no-physics-sand", false);
+        noPhysicsConcretePowder = getBoolean("physics.no-physics-concrete-powder", false);
+        noPhysicsAnvil = getBoolean("physics.no-physics-anvil",false);
         ropeLadders = getBoolean("physics.vine-like-rope-ladders", false);
         allowPortalAnywhere = getBoolean("physics.allow-portal-anywhere", false);
         preventWaterDamage = new HashSet<>(convertLegacyBlocks(getStringList("physics.disable-water-damage-blocks", null)));

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
@@ -370,6 +370,16 @@ public class WorldGuardBlockListener extends AbstractListener {
             return;
         }
 
+        if ((Materials.isConcretePowder(id) && wcfg.noPhysicsConcretePowder)) {
+            event.setCancelled(true);
+            return;
+        }
+
+        if ((Materials.isAnvil(id) && wcfg.noPhysicsAnvil)) {
+            event.setCancelled(true);
+            return;
+        }
+
         if (id == Material.NETHER_PORTAL && wcfg.allowPortalAnywhere) {
             event.setCancelled(true);
             return;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -28,6 +28,7 @@ import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.bukkit.cause.Cause;
 import com.sk89q.worldguard.bukkit.util.Entities;
 import com.sk89q.worldguard.bukkit.util.InteropUtils;
+import com.sk89q.worldguard.bukkit.util.Materials;
 import com.sk89q.worldguard.config.ConfigurationManager;
 import com.sk89q.worldguard.config.WorldConfiguration;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
@@ -806,6 +807,16 @@ public class WorldGuardEntityListener extends AbstractListener {
             }
 
             if ((id == Material.SAND || id == Material.RED_SAND) && wcfg.noPhysicsSand) {
+                event.setCancelled(true);
+                return;
+            }
+
+            if ((Materials.isConcretePowder(id) && wcfg.noPhysicsConcretePowder)) {
+                event.setCancelled(true);
+                return;
+            }
+
+            if ((Materials.isAnvil(id) && wcfg.noPhysicsAnvil)) {
                 event.setCancelled(true);
                 return;
             }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -1501,4 +1501,23 @@ public final class Materials {
     public static boolean isSculkGrowth(Material mat) {
         return mat == Material.SCULK || mat == Material.SCULK_VEIN;
     }
+
+    public static boolean isConcretePowder(Material mat) {
+        return mat == Material.BLACK_CONCRETE_POWDER
+                || mat == Material.BLUE_CONCRETE_POWDER
+                || mat == Material.BROWN_CONCRETE_POWDER
+                || mat == Material.CYAN_CONCRETE_POWDER
+                || mat == Material.GRAY_CONCRETE_POWDER
+                || mat == Material.GREEN_CONCRETE_POWDER
+                || mat == Material.LIGHT_BLUE_CONCRETE_POWDER
+                || mat == Material.YELLOW_CONCRETE_POWDER
+                || mat == Material.LIGHT_GRAY_CONCRETE_POWDER
+                || mat == Material.LIME_CONCRETE_POWDER
+                || mat == Material.MAGENTA_CONCRETE_POWDER
+                || mat == Material.ORANGE_CONCRETE_POWDER
+                || mat == Material.PINK_CONCRETE_POWDER
+                || mat == Material.PURPLE_CONCRETE_POWDER
+                || mat == Material.RED_CONCRETE_POWDER
+                || mat == Material.WHITE_CONCRETE_POWDER;
+    }
 }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -81,6 +81,8 @@ public abstract class WorldConfiguration {
     public boolean pumpkinScuba;
     public boolean noPhysicsGravel;
     public boolean noPhysicsSand;
+    public boolean noPhysicsConcretePowder;
+    public boolean noPhysicsAnvil;
     public boolean ropeLadders;
     public boolean allowPortalAnywhere;
     public Set<String> preventWaterDamage;


### PR DESCRIPTION
Fixes #1411
This feels like something often requested in Discord. There are in theory a couple more blocks that can be affected by gravity, but most of those seem like edge cases that are rarely relevant (except the dragon egg maybe, but I feel like the dragon egg has a lot more annoying things to block before gravity)