### PR TITLE
Special handling for Windcharges

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -65,6 +65,7 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Dispenser;
+import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
@@ -79,7 +80,6 @@ import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.ThrownPotion;
-import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -359,7 +359,7 @@ public class EventAbstractionListener extends AbstractListener {
     @EventHandler(ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent event) {
         Entity entity = event.getEntity();
-        if (entity instanceof WindCharge) {
+        if (entity instanceof AbstractWindCharge) {
             Iterator<Block> it = event.blockList().iterator();
             while (it.hasNext()) {
                 Block block = it.next();

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -79,6 +79,7 @@ import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.ThrownPotion;
+import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -357,6 +358,10 @@ public class EventAbstractionListener extends AbstractListener {
     @EventHandler(ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent event) {
         Entity entity = event.getEntity();
+        if (entity instanceof WindCharge) {
+            Events.fireBulkEventToCancel(event, new UseBlockEvent(event, create(entity), event.getLocation().getWorld(), event.blockList(), Material.AIR));
+            return;
+        }
         Events.fireBulkEventToCancel(event, new BreakBlockEvent(event, create(entity), event.getLocation().getWorld(), event.blockList(), Material.AIR));
         if (entity instanceof Creeper) {
             Cause.untrackParentCause(entity);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -152,6 +152,7 @@ import org.bukkit.util.Vector;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -359,7 +360,16 @@ public class EventAbstractionListener extends AbstractListener {
     public void onEntityExplode(EntityExplodeEvent event) {
         Entity entity = event.getEntity();
         if (entity instanceof WindCharge) {
-            Events.fireBulkEventToCancel(event, new UseBlockEvent(event, create(entity), event.getLocation().getWorld(), event.blockList(), Material.AIR));
+            Iterator<Block> it = event.blockList().iterator();
+            while (it.hasNext()) {
+                Block block = it.next();
+                UseBlockEvent useEvent = new UseBlockEvent(event, create(entity), block);
+                useEvent.setSilent(true);
+                Bukkit.getServer().getPluginManager().callEvent(useEvent);
+                if (useEvent.isCancelled()) {
+                    it.remove();
+                }
+            }
             return;
         }
         Events.fireBulkEventToCancel(event, new BreakBlockEvent(event, create(entity), event.getLocation().getWorld(), event.blockList(), Material.AIR));

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -44,6 +44,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EnderCrystal;
@@ -60,7 +61,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
-import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.Wither;
 import org.bukkit.entity.WitherSkull;
 import org.bukkit.entity.Wolf;
@@ -523,7 +523,7 @@ public class WorldGuardEntityListener extends AbstractListener {
                     }
                 }
             }
-        } else if (ent instanceof WindCharge) {
+        } else if (ent instanceof AbstractWindCharge) {
             if (wcfg.useRegions) {
                 for (Block block : event.blockList()) {
                     if (!WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().getApplicableRegions(BukkitAdapter.adapt(block.getLocation())).testState(null, Flags.WIND_CHARGE_BURST)) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -60,6 +60,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
+import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.Wither;
 import org.bukkit.entity.WitherSkull;
 import org.bukkit.entity.Wolf;
@@ -516,6 +517,16 @@ public class WorldGuardEntityListener extends AbstractListener {
                 for (Block block : event.blockList()) {
                     if (!StateFlag.test(WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().queryState(BukkitAdapter.adapt(block.getLocation()),
                             (RegionAssociable) null, Flags.WITHER_DAMAGE))) {
+                        event.blockList().clear();
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
+            }
+        } else if (ent instanceof WindCharge) {
+            if (wcfg.useRegions) {
+                for (Block block : event.blockList()) {
+                    if (!WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().getApplicableRegions(BukkitAdapter.adapt(block.getLocation())).testState(null, Flags.WIND_CHARGE_BURST)) {
                         event.blockList().clear();
                         event.setCancelled(true);
                         return;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -842,6 +842,7 @@ public final class Materials {
 
         MATERIAL_FLAGS.put(Material.ARMADILLO_SCUTE, 0);
         MATERIAL_FLAGS.put(Material.WOLF_ARMOR, 0);
+        MATERIAL_FLAGS.put(Material.WIND_CHARGE, 0);
 
         // Generated via tag
         putMaterialTag(Tag.WOODEN_DOORS, MODIFIED_ON_RIGHT);

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -93,6 +93,7 @@ public final class Flags {
     public static final StateFlag ENDERDRAGON_BLOCK_DAMAGE = register(new StateFlag("enderdragon-block-damage", true));
     public static final StateFlag GHAST_FIREBALL = register(new StateFlag("ghast-fireball", true));
     public static final StateFlag OTHER_EXPLOSION = register(new StateFlag("other-explosion", true));
+    public static final StateFlag WIND_CHARGE_BURST = register(new StateFlag("wind-charge-burst", true));
     public static final StateFlag WITHER_DAMAGE = register(new StateFlag("wither-damage", true));
     public static final StateFlag ENDER_BUILD = register(new StateFlag("enderman-grief", true));
     public static final StateFlag SNOWMAN_TRAILS = register(new StateFlag("snowman-trails", true));


### PR DESCRIPTION
WindCharges cause explosions but they never break blocks. So I removed the call of BlockBreakEvent for them and call UseBlockEvents instead, because wind charges may "use" blocks and added a separate flag.

I tried to use the UseBlockEvent as bulk event but then it will always check the same material for all locations, so that did not work. Thats why I use separate events for every block