### PR TITLE
Fix ItemStack conversion on block place on MC 1.21

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -218,8 +218,8 @@ public class EventAbstractionListener extends AbstractListener {
             Events.fireToCancel(event, new BreakBlockEvent(event, create(event.getPlayer()), previousState.getLocation(), previousState.getType()));
         }
 
-        if (!event.isCancelled()) {
-            ItemStack itemStack = new ItemStack(event.getBlockPlaced().getType(), 1);
+        if (!event.isCancelled() && !event.getItemInHand().isEmpty()) {
+            ItemStack itemStack = event.getItemInHand().asQuantity(1);
             Events.fireToCancel(event, new UseItemEvent(event, create(event.getPlayer()), event.getPlayer().getWorld(), itemStack));
         }
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -218,8 +218,8 @@ public class EventAbstractionListener extends AbstractListener {
             Events.fireToCancel(event, new BreakBlockEvent(event, create(event.getPlayer()), previousState.getLocation(), previousState.getType()));
         }
 
-        if (!event.isCancelled() && !event.getItemInHand().isEmpty()) {
-            ItemStack itemStack = event.getItemInHand().asQuantity(1);
+        ItemStack itemStack = event.getItemInHand();
+        if (!event.isCancelled() && !itemStack.isEmpty()) {
             Events.fireToCancel(event, new UseItemEvent(event, create(event.getPlayer()), event.getPlayer().getWorld(), itemStack));
         }
 


### PR DESCRIPTION
This issue is present in 1.21 because some materials do not convert 1:1 to item types.  
This throws an exception in the ItemStack constructor.  
Example: WALL_TORCH is a valid block but not a valid item, only TORCH is a valid item.

So, use the item in hand instead, creating a copy with quantity set to 1, for issuing the use item event.

--------

To reproduce: place a torch on the wall.

If a different solution is preferred that is fine too and this MR may be closed but I don't see an issue with using the item in hand as I believe it is only changed after the event has completed, so it will contain the item placed even if the quantity was 1.