### PR TITLE
Optimize and cleanup explosion events from entities

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitWorldConfiguration.java
@@ -215,6 +215,7 @@ public class BukkitWorldConfiguration extends YamlWorldConfiguration {
         blockEnderDragonPortalCreation = getBoolean("mobs.block-enderdragon-portal-creation", false);
         blockFireballExplosions = getBoolean("mobs.block-fireball-explosions", false);
         blockFireballBlockDamage = getBoolean("mobs.block-fireball-block-damage", false);
+        blockWindChargeExplosions = getBoolean("mobs.block-windcharge-explosions", false);
         antiWolfDumbness = getBoolean("mobs.anti-wolf-dumbness", false);
         allowTamedSpawns = getBoolean("mobs.allow-tamed-spawns", true);
         disableEndermanGriefing = getBoolean("mobs.disable-enderman-griefing", false);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/event/block/AbstractBlockEvent.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/event/block/AbstractBlockEvent.java
@@ -45,7 +45,7 @@ import javax.annotation.Nullable;
  * This event is an internal event. We do not recommend handling or throwing
  * this event or its subclasses as the interface is highly subject to change.
  */
-abstract class AbstractBlockEvent extends DelegateEvent implements BulkEvent {
+public abstract class AbstractBlockEvent extends DelegateEvent implements BulkEvent {
 
     private final World world;
     private List<Block> blocks;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -68,6 +68,7 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Dispenser;
+import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
@@ -117,6 +118,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
+import org.bukkit.event.entity.EntityKnockbackByEntityEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.EntityTameEvent;
 import org.bukkit.event.entity.EntityUnleashEvent;
@@ -355,6 +357,17 @@ public class EventAbstractionListener extends AbstractListener {
             handleFallingBlock(event, denied);
         }
 
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityKnockbackByEntity(EntityKnockbackByEntityEvent event) {
+        Entity damager = event.getSourceEntity();
+
+        final DamageEntityEvent eventToFire = new DamageEntityEvent(event, create(damager), event.getEntity());
+        if (damager instanceof AbstractWindCharge) {
+            eventToFire.getRelevantFlags().add(Flags.WIND_CHARGE_BURST);
+        }
+        Events.fireToCancel(event, eventToFire);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -47,7 +47,6 @@ import com.sk89q.worldguard.bukkit.util.Events;
 import com.sk89q.worldguard.bukkit.util.Materials;
 import com.sk89q.worldguard.config.WorldConfiguration;
 import com.sk89q.worldguard.protection.flags.Flags;
-import com.sk89q.worldguard.protection.flags.StateFlag;
 import io.papermc.lib.PaperLib;
 import io.papermc.paper.event.player.PlayerOpenSignEvent;
 import org.bukkit.Bukkit;
@@ -68,8 +67,8 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Dispenser;
-import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.AreaEffectCloud;
+import org.bukkit.entity.BreezeWindCharge;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -83,6 +82,7 @@ import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.ThrownPotion;
+import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -328,10 +328,10 @@ public class EventAbstractionListener extends AbstractListener {
 
         // Fire two events: one as BREAK and one as PLACE
         if (toType != Material.AIR && fromType != Material.AIR) {
-            BreakBlockEvent breakDelagate = new BreakBlockEvent(event, cause, block);
-            setDelegateEventMaterialOptions(breakDelagate, fromType, toType);
+            BreakBlockEvent breakDelegate = new BreakBlockEvent(event, cause, block);
+            setDelegateEventMaterialOptions(breakDelegate, fromType, toType);
             boolean denied;
-            if (!(denied = Events.fireToCancel(event, breakDelagate))) {
+            if (!(denied = Events.fireToCancel(event, breakDelegate))) {
                 PlaceBlockEvent placeDelegate = new PlaceBlockEvent(event, cause, block.getLocation(), toType);
                 setDelegateEventMaterialOptions(placeDelegate, fromType, toType);
                 denied = Events.fireToCancel(event, placeDelegate);
@@ -364,7 +364,9 @@ public class EventAbstractionListener extends AbstractListener {
         Entity damager = event.getSourceEntity();
 
         final DamageEntityEvent eventToFire = new DamageEntityEvent(event, create(damager), event.getEntity());
-        if (damager instanceof AbstractWindCharge) {
+        if (damager instanceof BreezeWindCharge) {
+            eventToFire.getRelevantFlags().add(Flags.BREEZE_WIND_CHARGE);
+        } else if (damager instanceof WindCharge) {
             eventToFire.getRelevantFlags().add(Flags.WIND_CHARGE_BURST);
         }
         Events.fireToCancel(event, eventToFire);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -330,7 +330,6 @@ public class WorldGuardEntityListener extends AbstractListener {
                         }
                     }
                     if (wcfg.useRegions) {
-                        WorldGuardPlugin.inst().getLogger().info("Getting damager type " + event.getDamager().getType());
                         RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
                         if (!query.testState(localPlayer.getLocation(), localPlayer, Entities.getExplosionFlag(event.getDamager())) && wcfg.explosionFlagCancellation) {
                             event.setCancelled(true);

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -44,6 +44,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EnderCrystal;
@@ -311,10 +312,14 @@ public class WorldGuardEntityListener extends AbstractListener {
                         return;
                     }
                 }
-                if (event.getDamager() instanceof Fireball) {
-                    Fireball fireball = (Fireball) event.getDamager();
+                if (event.getDamager() instanceof Fireball fireball) {
                     if (fireball instanceof WitherSkull) {
                         if (wcfg.blockWitherSkullExplosions) {
+                            event.setCancelled(true);
+                            return;
+                        }
+                    } else if (fireball instanceof AbstractWindCharge) {
+                        if (wcfg.blockWindChargeExplosions) {
                             event.setCancelled(true);
                             return;
                         }
@@ -325,8 +330,9 @@ public class WorldGuardEntityListener extends AbstractListener {
                         }
                     }
                     if (wcfg.useRegions) {
+                        WorldGuardPlugin.inst().getLogger().info("Getting damager type " + event.getDamager().getType());
                         RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
-                        if (!query.testState(localPlayer.getLocation(), localPlayer, Flags.GHAST_FIREBALL) && wcfg.explosionFlagCancellation) {
+                        if (!query.testState(localPlayer.getLocation(), localPlayer, Entities.getExplosionFlag(event.getDamager())) && wcfg.explosionFlagCancellation) {
                             event.setCancelled(true);
                             return;
                         }
@@ -483,6 +489,11 @@ public class WorldGuardEntityListener extends AbstractListener {
                     event.blockList().clear();
                     return;
                 }
+            } else if (ent instanceof AbstractWindCharge) {
+                if (wcfg.blockWindChargeExplosions) {
+                    event.setCancelled(true);
+                    return;
+                }
             } else {
                 if (wcfg.blockFireballExplosions) {
                     event.setCancelled(true);
@@ -491,16 +502,6 @@ public class WorldGuardEntityListener extends AbstractListener {
                 if (wcfg.blockFireballBlockDamage) {
                     event.blockList().clear();
                     return;
-                }
-            }
-            // allow wither skull blocking since there is no dedicated flag atm
-            if (wcfg.useRegions) {
-                for (Block block : event.blockList()) {
-                    if (!WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().getApplicableRegions(BukkitAdapter.adapt(block.getLocation())).testState(null, Flags.GHAST_FIREBALL)) {
-                        event.blockList().clear();
-                        if (wcfg.explosionFlagCancellation) event.setCancelled(true);
-                        return;
-                    }
                 }
             }
         } else if (ent instanceof Wither) {
@@ -512,33 +513,13 @@ public class WorldGuardEntityListener extends AbstractListener {
                 event.blockList().clear();
                 return;
             }
-            if (wcfg.useRegions) {
-                for (Block block : event.blockList()) {
-                    if (!StateFlag.test(WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().queryState(BukkitAdapter.adapt(block.getLocation()),
-                            (RegionAssociable) null, Flags.WITHER_DAMAGE))) {
-                        event.blockList().clear();
-                        event.setCancelled(true);
-                        return;
-                    }
-                }
-            }
         } else {
             // unhandled entity
             if (wcfg.blockOtherExplosions) {
                 event.setCancelled(true);
                 return;
             }
-            if (wcfg.useRegions) {
-                for (Block block : event.blockList()) {
-                    if (!WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery().getApplicableRegions(BukkitAdapter.adapt(block.getLocation())).testState(null, Flags.OTHER_EXPLOSION)) {
-                        event.blockList().clear();
-                        if (wcfg.explosionFlagCancellation) event.setCancelled(true);
-                        return;
-                    }
-                }
-            }
         }
-
 
         if (wcfg.signChestProtection) {
             for (Block block : event.blockList()) {
@@ -589,6 +570,11 @@ public class WorldGuardEntityListener extends AbstractListener {
         } else if (event.getEntityType() == EntityType.TNT
                 || event.getEntityType() == EntityType.TNT_MINECART) {
             if (wcfg.blockTNTExplosions) {
+                event.setCancelled(true);
+                return;
+            }
+        } else if (event instanceof AbstractWindCharge) {
+            if (wcfg.blockWindChargeExplosions) {
                 event.setCancelled(true);
                 return;
             }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
@@ -21,11 +21,11 @@ package com.sk89q.worldguard.bukkit.util;
 
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
-import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.Allay;
 import org.bukkit.entity.Ambient;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Arrow;
+import org.bukkit.entity.BreezeWindCharge;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.EnderDragon;
@@ -48,6 +48,7 @@ import org.bukkit.entity.Steerable;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.WindCharge;
 import org.bukkit.entity.Wither;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -260,7 +261,8 @@ public final class Entities {
      */
     public static @Nonnull StateFlag getExplosionFlag(Entity entity) {
         return switch (entity) {
-            case AbstractWindCharge abstractWindCharge -> Flags.WIND_CHARGE_BURST;
+            case BreezeWindCharge breezeWindCharge -> Flags.BREEZE_WIND_CHARGE;
+            case WindCharge windCharge -> Flags.WIND_CHARGE_BURST;
             case Firework firework -> Flags.FIREWORK_DAMAGE;
             case Fireball fireball -> Flags.GHAST_FIREBALL;
             case Wither wither -> Flags.WITHER_DAMAGE;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
@@ -19,6 +19,9 @@
 
 package com.sk89q.worldguard.bukkit.util;
 
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.Allay;
 import org.bukkit.entity.Ambient;
 import org.bukkit.entity.ArmorStand;
@@ -28,6 +31,8 @@ import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Firework;
 import org.bukkit.entity.Flying;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.LivingEntity;
@@ -43,11 +48,13 @@ import org.bukkit.entity.Steerable;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.Wither;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.projectiles.ProjectileSource;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class Entities {
@@ -243,6 +250,21 @@ public final class Entities {
         return switch (spawnReason) {
             case CUSTOM, COMMAND -> true;
             default -> false;
+        };
+    }
+
+    /**
+     * Get the explosion flag relevant for an entity type.
+     * @param entity the entity
+     * @return the relevant StateFlag or OTHER_EXPLOSION if none is matching
+     */
+    public static @Nonnull StateFlag getExplosionFlag(Entity entity) {
+        return switch (entity) {
+            case AbstractWindCharge abstractWindCharge -> Flags.WIND_CHARGE_BURST;
+            case Firework firework -> Flags.FIREWORK_DAMAGE;
+            case Fireball fireball -> Flags.GHAST_FIREBALL;
+            case Wither wither -> Flags.WITHER_DAMAGE;
+            case null, default -> Flags.OTHER_EXPLOSION;
         };
     }
 }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -22,6 +22,7 @@ package com.sk89q.worldguard.bukkit.util;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.sk89q.worldguard.protection.flags.Flags;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.entity.EntityType;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -22,7 +22,6 @@ package com.sk89q.worldguard.bukkit.util;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.sk89q.worldguard.protection.flags.Flags;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.entity.EntityType;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/WorldConfiguration.java
@@ -101,6 +101,7 @@ public abstract class WorldConfiguration {
     public boolean blockEnderDragonPortalCreation;
     public boolean blockFireballExplosions;
     public boolean blockFireballBlockDamage;
+    public boolean blockWindChargeExplosions;
     public boolean blockOtherExplosions;
     public boolean blockEntityPaintingDestroy;
     public boolean blockEntityItemFrameDestroy;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -74,6 +74,7 @@ public final class Flags {
     public static final StateFlag FIREWORK_DAMAGE = register(new StateFlag("firework-damage", false));
     public static final StateFlag USE_ANVIL = register(new StateFlag("use-anvil", false));
     public static final StateFlag USE_DRIPLEAF = register(new StateFlag("use-dripleaf", false));
+    public static final StateFlag WIND_CHARGE_BURST = register(new StateFlag("wind-charge-burst", false));
 
     // These flags are similar to the ones above (used in tandem with BUILD),
     // but their defaults are set to TRUE because it is more user friendly.
@@ -93,7 +94,7 @@ public final class Flags {
     public static final StateFlag ENDERDRAGON_BLOCK_DAMAGE = register(new StateFlag("enderdragon-block-damage", true));
     public static final StateFlag GHAST_FIREBALL = register(new StateFlag("ghast-fireball", true));
     public static final StateFlag OTHER_EXPLOSION = register(new StateFlag("other-explosion", true));
-    public static final StateFlag WIND_CHARGE_BURST = register(new StateFlag("wind-charge-burst", true));
+    public static final StateFlag BREEZE_WIND_CHARGE = register(new StateFlag("breeze-charge-explosion", true));
     public static final StateFlag WITHER_DAMAGE = register(new StateFlag("wither-damage", true));
     public static final StateFlag ENDER_BUILD = register(new StateFlag("enderman-grief", true));
     public static final StateFlag SNOWMAN_TRAILS = register(new StateFlag("snowman-trails", true));


### PR DESCRIPTION
This PR is the start of a cleanup of explosion handling in WorldGuard.

Currently this draft has some ToDos:

- [x] Hitting players with the wind charge are not protected by the EntityDamageByEntityEvent. (requires Paper Debug session)
- [ ] I moved the flag handling for explosion block damage to EventAbstractionListener. Validate this is not breaking.

Fixes #2099 and #2097