### PR TITLE
Avoid using metadata storage if possible

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
@@ -76,7 +76,7 @@ public final class Cause {
     /**
      * Create a new instance.
      *
-     * @param causes   a list of causes
+     * @param causes a list of causes
      * @param indirect whether the cause is indirect
      */
     private Cause(List<Object> causes, boolean indirect) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
@@ -21,7 +21,6 @@ package com.sk89q.worldguard.bukkit.cause;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.bukkit.BukkitWorldConfiguration;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.bukkit.internal.WGMetadata;
@@ -341,10 +340,9 @@ public final class Cause {
                         ((LightningStrike) o).getCausingEntity() != null) {
                     indirect = true;
                     addAll(((LightningStrike) o).getCausingEntity());
-                } else if (o instanceof FallingBlock f && PaperLib.isPaper() &&
-                        WorldGuardPlugin.inst().getConfigManager().get(BukkitAdapter.adapt(f.getWorld())).usePaperEntityOrigin) {
+                } else if (o instanceof FallingBlock f && PaperLib.isPaper() && f.getOrigin() != null) {
                     indirect = true;
-                    addAll(f.getOrigin());
+                    addAll(f.getOrigin().getBlock());
                 }
 
                 // Add manually tracked parent causes

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
@@ -21,6 +21,7 @@ package com.sk89q.worldguard.bukkit.cause;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.bukkit.BukkitWorldConfiguration;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.bukkit.internal.WGMetadata;
@@ -32,8 +33,10 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Creature;
+import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Player;
@@ -74,7 +77,7 @@ public final class Cause {
     /**
      * Create a new instance.
      *
-     * @param causes a list of causes
+     * @param causes   a list of causes
      * @param indirect whether the cause is indirect
      */
     private Cause(List<Object> causes, boolean indirect) {
@@ -326,15 +329,22 @@ public final class Cause {
                             addAll(player.getPlayer()); // player object if online, else null
                         }
                     }
-                } else if (o instanceof Creature && ((Creature) o).getTarget() != null) {
+                } else if (o instanceof Creeper c) {
                     indirect = true;
-                    addAll(((Creature) o).getTarget());
+                    addAll(c.getTarget(), c.getIgniter());
+                } else if (o instanceof Creature c) {
+                    indirect = true;
+                    addAll(c.getTarget());
                 } else if (o instanceof BlockProjectileSource) {
                     addAll(((BlockProjectileSource) o).getBlock());
                 } else if (o instanceof LightningStrike && PaperLib.isPaper() &&
                         ((LightningStrike) o).getCausingEntity() != null) {
                     indirect = true;
                     addAll(((LightningStrike) o).getCausingEntity());
+                } else if (o instanceof FallingBlock f && PaperLib.isPaper() &&
+                        WorldGuardPlugin.inst().getConfigManager().get(BukkitAdapter.adapt(f.getWorld())).usePaperEntityOrigin) {
+                    indirect = true;
+                    addAll(f.getOrigin());
                 }
 
                 // Add manually tracked parent causes

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -347,7 +347,8 @@ public class EventAbstractionListener extends AbstractListener {
         } else if (toType == Material.AIR) {
             // Track the source so later we can create a proper chain of causes
             if (entity instanceof FallingBlock) {
-                if (!getWorldConfig(event.getEntity().getWorld()).usePaperEntityOrigin) {
+                if (!PaperLib.isPaper()) {
+                    // On paper we use FallingBlock#getOrigin to get the origin location, on spigot we store it.
                     Cause.trackParentCause(entity, block);
                 }
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -347,7 +347,9 @@ public class EventAbstractionListener extends AbstractListener {
         } else if (toType == Material.AIR) {
             // Track the source so later we can create a proper chain of causes
             if (entity instanceof FallingBlock) {
-                Cause.trackParentCause(entity, block);
+                if (!getWorldConfig(event.getEntity().getWorld()).usePaperEntityOrigin) {
+                    Cause.trackParentCause(entity, block);
+                }
 
                 // Switch around the event
                 Events.fireToCancel(event, new SpawnEntityEvent(event, create(block), entity));
@@ -864,12 +866,7 @@ public class EventAbstractionListener extends AbstractListener {
         if (matchingItem != null && hasInteractBypass(world, matchingItem)) {
             useEntityEvent.setAllowed(true);
         }
-        if (!Events.fireToCancel(event, useEntityEvent)) {
-            // so this is a hack but CreeperIgniteEvent doesn't actually tell us who, so we need to do it here
-            if (item.getType() == Material.FLINT_AND_STEEL && entity.getType() == EntityType.CREEPER) {
-                Cause.trackParentCause(entity, player);
-            }
-        }
+        Events.fireToCancel(event, useEntityEvent);
     }
 
     @EventHandler(ignoreCancelled = true)


### PR DESCRIPTION
Currently the sources for creeper explosions and falling blocks are stored in the metadata section of bukkit. The metadata section is never cleared so with a lot of falling blocks there is a memory leak.

This PR removes the tracking for Creeper explosions since there is already `Creeper#getIgniter()`.

For Paper we use `FallingBlock#getOrigin()` ~~if the config options usePaperEntityOrigin is enabled.~~

Closes #1535