### PR TITLE
Drop spigot api as dependency in gradle

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ junit-jupiter-api.module = "org.junit.jupiter:junit-jupiter-api"
 junit-jupiter-params.module = "org.junit.jupiter:junit-jupiter-params"
 junit-jupiter-engine.module = "org.junit.jupiter:junit-jupiter-engine"
 
-spigot = "org.spigotmc:spigot-api:1.21.4-R0.1-SNAPSHOT"
 paperApi = "io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT"
 paperLib = "io.papermc:paperlib:1.0.8"
 

--- a/worldguard-bukkit/build.gradle.kts
+++ b/worldguard-bukkit/build.gradle.kts
@@ -5,23 +5,10 @@ plugins {
     id("buildlogic.platform")
 }
 
-val localImplementation = configurations.create("localImplementation") {
-    description = "Dependencies used locally, but provided by the runtime Bukkit implementation"
-    isCanBeConsumed = false
-    isCanBeResolved = false
-}
-configurations["compileOnly"].extendsFrom(localImplementation)
-configurations["testImplementation"].extendsFrom(localImplementation)
-
 dependencies {
     "api"(project(":worldguard-core"))
     "api"(libs.worldedit.bukkit) { isTransitive = false }
     "compileOnly"(libs.commandbook) { isTransitive = false }
-    // Technically this is api, but everyone should already have some form of the bukkit API
-    // Avoid pulling in another one, especially one so outdated.
-    "localImplementation"(libs.spigot) {
-        exclude("junit", "junit")
-    }
 
     "compileOnly"(libs.jetbrains.annotations) {
         because("Resolving Spigot annotations")


### PR DESCRIPTION
This removes the spigot-api as dependency. paper-api contains spigot-api in 1.21.4 so depending on both results in conflicts.

I don't see a reason why there is the localImplementation configuration in gradle. If we don't need it this can be merged directly.