### PR TITLE
Port outside repo usage elimination

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
     gradlePluginPortal()
+    maven {
+        name = "EngineHub Repository"
+        url = uri("https://maven.enginehub.org/repo/")
+    }
 }
 
 dependencies {

--- a/build-logic/src/main/kotlin/buildlogic.common.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.common.gradle.kts
@@ -10,10 +10,13 @@ group = rootProject.group
 version = rootProject.version
 
 repositories {
-    mavenCentral()
     maven {
         name = "EngineHub"
         url = uri("https://maven.enginehub.org/repo/")
+    }
+    mavenCentral()
+    afterEvaluate {
+        killNonEngineHubRepositories()
     }
 }
 

--- a/build-logic/src/main/kotlin/repositoriesHelper.kt
+++ b/build-logic/src/main/kotlin/repositoriesHelper.kt
@@ -1,0 +1,26 @@
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.logging.Logging
+
+// The primary point of this is repository up-time. We replace most other repositories with EngineHub's repository.
+// This is because we have stronger up-time guarantees for our repository. However, Maven Central and Sonatype are
+// clearly even better, so we allow those as well. We also allow Gradle's plugin repository.
+private val ALLOWED_PREFIXES = listOf(
+    "https://maven.enginehub.org",
+    "https://repo.maven.apache.org/maven2/",
+    "https://s01.oss.sonatype.org/content/repositories/snapshots/",
+    "https://plugins.gradle.org",
+    "file:"
+)
+private val LOGGER = Logging.getLogger("repositoriesHelper")
+
+fun RepositoryHandler.killNonEngineHubRepositories() {
+    val toRemove = mutableListOf<MavenArtifactRepository>()
+    for (repo in this) {
+        if (repo is MavenArtifactRepository && !ALLOWED_PREFIXES.any { repo.url.toString().startsWith(it) }) {
+            LOGGER.info("Removing non-EngineHub repository: {}", repo.url)
+            toRemove.add(repo)
+        }
+    }
+    toRemove.forEach { remove(it) }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-worldedit = "7.3.0"
+worldedit = "7.3.9"
 
 # Minimum versions we apply to make dependencies support newer Java
 minimumAsm = "9.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,39 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        maven {
+            name = "EngineHub"
+            url = uri("https://maven.enginehub.org/repo/")
+        }
     }
 }
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+dependencyResolutionManagement {
+    repositories {
+        maven {
+            name = "EngineHub"
+            url = uri("https://maven.enginehub.org/repo/")
+        }
+        gradle.settingsEvaluated {
+            // Duplicates repositoriesHelper.kt, since we can't import it
+            val allowedPrefixes = listOf(
+                "https://maven.enginehub.org",
+                "https://repo.maven.apache.org/maven2/",
+                "file:"
+            )
+
+            for (repo in this@repositories) {
+                if (repo is MavenArtifactRepository) {
+                    val urlString = repo.url.toString()
+                    check(allowedPrefixes.any { urlString.startsWith(it) }) {
+                        "Only EngineHub/Central repositories are allowed: ${repo.url} found"
+                    }
+                }
+            }
+        }
+    }
 }
 
 logger.lifecycle("""


### PR DESCRIPTION
This ports https://github.com/EngineHub/WorldEdit/commit/da223671a5e5d0107d502234d7378522db162e3c and https://github.com/EngineHub/WorldEdit/commit/46eff6ab6fc90655c2c0630c86cd617c50fbd595 from WorldEdit as well as updating Gradle. Since WG doesn't use outside repos anyway atm this shouldn't change anything and is simply to keep the build-scripts up to date with WE.