### PR TITLE
add ability to disable region in region

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -160,6 +160,8 @@ public final class RegionCommands extends RegionCommandsBase {
             region = checkRegionFromSelection(sender, id);
         }
 
+        checkRegionInRegion(manager, region);
+
         RegionAdder task = new RegionAdder(manager, region);
         task.addOwnersFromCommand(args, 2);
 
@@ -211,6 +213,8 @@ public final class RegionCommands extends RegionCommandsBase {
         } else {
             region = checkRegionFromSelection(sender, id);
         }
+
+        checkRegionInRegion(manager, region);
 
         region.copyFrom(existing);
 

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
@@ -169,6 +169,22 @@ class RegionCommandsBase {
         return region;
     }
 
+    /**
+     * Checks if the given region is within any region and if so throws a {@link CommandException}.
+     *
+     * @param regionManager the region manager
+     * @param region the region to check
+     * @throws CommandException thrown if a region was found within a region
+     */
+    protected static void checkRegionInRegion(RegionManager regionManager, ProtectedRegion region) throws CommandException {
+        boolean disableRegionInRegion = WorldGuard.getInstance().getPlatform().getGlobalStateManager().disableRegionInRegion;
+
+        if (disableRegionInRegion) {
+            if (!region.getIntersectingRegions(regionManager.getRegions().values()).isEmpty()) {
+                throw new CommandException("Region " + region.getId() + " cannot be defined within another region");
+            }
+        }
+    }
 
     /**
      * Get the region at the player's location, if possible.

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/ConfigurationManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/ConfigurationManager.java
@@ -79,6 +79,7 @@ public abstract class ConfigurationManager {
     public boolean disablePermissionCache;
     public boolean disableDefaultBypass;
     public boolean announceBypassStatus;
+    public boolean disableRegionInRegion;
 
     @Unreported public Map<String, String> hostKeys = new HashMap<>();
     public boolean hostKeysAllowFMLClients;

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/config/YamlConfigurationManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/config/YamlConfigurationManager.java
@@ -58,6 +58,7 @@ public abstract class YamlConfigurationManager extends ConfigurationManager {
         useRegionsCreatureSpawnEvent = config.getBoolean("regions.use-creature-spawn-event", true);
         disableDefaultBypass = config.getBoolean("regions.disable-bypass-by-default", false);
         announceBypassStatus = config.getBoolean("regions.announce-bypass-status", false);
+        disableRegionInRegion = config.getBoolean("disable-region-in-region", false);
 
         useGodPermission = config.getBoolean("auto-invincible", config.getBoolean("auto-invincible-permission", false));
         useGodGroup = config.getBoolean("auto-invincible-group", false);


### PR DESCRIPTION
Adds the ability to prevent users from creating a region which is within another region.
This is configurable and is per default set to false (which is the normal behavior)

I added this because I needed to prevent my players or trolls to protect over another players region.
Dunno if this is already possible but this here is working fine for me.

![image](https://github.com/user-attachments/assets/bf8dde69-7591-4002-8e74-c4c1bb649c5c)
