### PR TITLE
Update to 1.21.5.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ junit-jupiter-api.module = "org.junit.jupiter:junit-jupiter-api"
 junit-jupiter-params.module = "org.junit.jupiter:junit-jupiter-params"
 junit-jupiter-engine.module = "org.junit.jupiter:junit-jupiter-engine"
 
-paperApi = "io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT"
+paperApi = "io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT"
 paperLib = "io.papermc:paperlib:1.0.8"
 
 dummypermscompat = "com.sk89q:dummypermscompat:1.10"

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -75,7 +75,8 @@ public final class Materials {
         ENTITY_ITEMS.put(EntityType.FURNACE_MINECART, Material.FURNACE_MINECART);
         ENTITY_ITEMS.put(EntityType.TNT_MINECART, Material.TNT_MINECART);
         ENTITY_ITEMS.put(EntityType.HOPPER_MINECART, Material.HOPPER_MINECART);
-        ENTITY_ITEMS.put(EntityType.POTION, Material.POTION);
+        ENTITY_ITEMS.put(EntityType.SPLASH_POTION, Material.SPLASH_POTION);
+        ENTITY_ITEMS.put(EntityType.LINGERING_POTION, Material.LINGERING_POTION);
         ENTITY_ITEMS.put(EntityType.EGG, Material.EGG);
         ENTITY_ITEMS.put(EntityType.ARMOR_STAND, Material.ARMOR_STAND);
         ENTITY_ITEMS.put(EntityType.END_CRYSTAL, Material.END_CRYSTAL);
@@ -935,6 +936,19 @@ public final class Materials {
         MATERIAL_FLAGS.put(Material.CHISELED_RESIN_BRICKS, 0);
         MATERIAL_FLAGS.put(Material.MACE, 0);
         MATERIAL_FLAGS.put(Material.RESIN_BRICK, 0);
+
+        // 1.21.5
+        MATERIAL_FLAGS.put(Material.BUSH, 0);
+        MATERIAL_FLAGS.put(Material.CACTUS_FLOWER, 0);
+        MATERIAL_FLAGS.put(Material.FIREFLY_BUSH, 0);
+        MATERIAL_FLAGS.put(Material.LEAF_LITTER, 0);
+        MATERIAL_FLAGS.put(Material.SHORT_DRY_GRASS, 0);
+        MATERIAL_FLAGS.put(Material.TALL_DRY_GRASS, 0);
+        MATERIAL_FLAGS.put(Material.WILDFLOWERS, 0);
+        MATERIAL_FLAGS.put(Material.TEST_BLOCK, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.TEST_INSTANCE_BLOCK, MODIFIED_ON_RIGHT);
+        MATERIAL_FLAGS.put(Material.BLUE_EGG, 0);
+        MATERIAL_FLAGS.put(Material.BROWN_EGG, 0);
 
         Stream.concat(Stream.concat(
                 Tag.CORAL_BLOCKS.getValues().stream(),

--- a/worldguard-bukkit/src/main/resources/plugin.yml
+++ b/worldguard-bukkit/src/main/resources/plugin.yml
@@ -2,5 +2,4 @@ name: WorldGuard
 main: com.sk89q.worldguard.bukkit.WorldGuardPlugin
 version: "${internalVersion}"
 depend: [WorldEdit]
-softdepend: [CommandBook]
-api-version: "1.21"
+api-version: "1.21.5"


### PR DESCRIPTION
It doesn't seem like there's much new behavior in this game drop. In theory, the existing release should work through commodore with the exception of overprotecting these new blocks.