### PR TITLE
Update deprecated PlayerLoginEvent to AsyncPlayerPreLoginEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.16
+* Replace deprecated PlayerLoginEvent with AsyncPlayerPreLoginEvent
+
 ## 7.0.14
 
 * Update to 1.21.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.sk89q.worldguard
-version=7.0.15-SNAPSHOT
+version=7.0.16-SNAPSHOT
 
 org.gradle.parallel=true

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
@@ -49,15 +49,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.event.player.PlayerGameModeChangeEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerItemHeldEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 
@@ -66,6 +58,8 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+
+import static org.bukkit.Bukkit.getPlayer;
 
 /**
  * Handles all events thrown in relation to a player.
@@ -168,8 +162,8 @@ public class WorldGuardPlayerListener extends AbstractListener {
     }
 
     @EventHandler(ignoreCancelled = true)
-    public void onPlayerLogin(PlayerLoginEvent event) {
-        Player player = event.getPlayer();
+    public void onPlayerLogin(AsyncPlayerPreLoginEvent event) {
+        Player player = getPlayer(event.getUniqueId());
         ConfigurationManager cfg = getConfig();
 
         String hostKey = cfg.hostKeys.get(player.getUniqueId().toString());
@@ -187,7 +181,7 @@ public class WorldGuardPlayerListener extends AbstractListener {
             if (!hostname.equals(hostKey)
                     && !(cfg.hostKeysAllowFMLClients &&
                             (hostname.equals(hostKey + "\u0000FML\u0000") || hostname.equals(hostKey + "\u0000FML2\u0000")))) {
-                event.disallow(PlayerLoginEvent.Result.KICK_OTHER,
+                event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER,
                         "You did not join with the valid host key!");
                 log.warning("WorldGuard host key check: " +
                         player.getName() + " joined with '" + hostname +

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
@@ -55,6 +55,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Iterator;
 import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -128,6 +129,10 @@ public class WorldGuardPlayerListener extends AbstractListener {
         Events.fire(new ProcessPlayerEvent(player));
         WorldGuard.getInstance().getExecutorService().submit(() ->
             WorldGuard.getInstance().getProfileCache().put(new Profile(player.getUniqueId(), player.getName())));
+
+        if (cfg.deopOnJoin) {
+            player.setOp(false);
+        }
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -163,12 +168,13 @@ public class WorldGuardPlayerListener extends AbstractListener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerLogin(AsyncPlayerPreLoginEvent event) {
-        Player player = getPlayer(event.getUniqueId());
+        UUID uuid = event.getUniqueId();
+        String name = event.getName();
         ConfigurationManager cfg = getConfig();
 
-        String hostKey = cfg.hostKeys.get(player.getUniqueId().toString());
+        String hostKey = cfg.hostKeys.get(uuid);
         if (hostKey == null) {
-            hostKey = cfg.hostKeys.get(player.getName().toLowerCase());
+            hostKey = cfg.hostKeys.get(name.toLowerCase());
         }
 
         if (hostKey != null) {
@@ -184,14 +190,10 @@ public class WorldGuardPlayerListener extends AbstractListener {
                 event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER,
                         "You did not join with the valid host key!");
                 log.warning("WorldGuard host key check: " +
-                        player.getName() + " joined with '" + hostname +
+                        name + " joined with '" + hostname +
                         "' but '" + hostKey + "' was expected. Kicked!");
                 return;
             }
-        }
-
-        if (cfg.deopOnJoin) {
-            player.setOp(false);
         }
     }
 


### PR DESCRIPTION
This PR updates the plugin to replace usage of the deprecated `PlayerLoginEvent` event with `AsyncPlayerPreLoginEvent` per issue #2216, following the latest Bukkit API deprecations.