### PR TITLE
Generating an End Portal should not trigger BlockMultiPlaceEvent

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -210,6 +210,9 @@ public class EventAbstractionListener extends AbstractListener {
     }
 
     private boolean isExemptBlock(Material material) {
+        // Determines if the block is exempt from BlockMultiPlaceEvent check
+        // Canceling BlockMultiPlaceEvent from these source blocks causes item duplication bug
+        // https://github.com/PaperMC/Paper/issues/13586
         return switch (material) {
             case BEDROCK, END_PORTAL_FRAME -> true;
             default -> false;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -209,8 +209,20 @@ public class EventAbstractionListener extends AbstractListener {
         }
     }
 
+    private boolean isExemptBlock(Material material) {
+        return switch (material) {
+            case BEDROCK, END_PORTAL_FRAME -> true;
+            default -> false;
+        };
+    }
+
     @EventHandler(ignoreCancelled = true)
     public void onBlockMultiPlace(BlockMultiPlaceEvent event) {
+        // Allow end_portal generation if player can interact with block
+        // avoiding upstream issues
+        if (isExemptBlock(event.getBlockPlaced().getType())) {
+            return;
+        }
         List<Block> placed = event.getReplacedBlockStates().stream().map(BlockState::getBlock).collect(Collectors.toList());
         int origAmt = placed.size();
         PlaceBlockEvent delegateEvent = new PlaceBlockEvent(event, create(event.getPlayer()), event.getBlock().getWorld(),

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -210,8 +210,8 @@ public class EventAbstractionListener extends AbstractListener {
     }
 
     private boolean isExemptBlock(Material material) {
-        // Determines if the block is exempt from BlockMultiPlaceEvent check
-        // Canceling BlockMultiPlaceEvent from these source blocks causes item duplication bug
+        // Generating an End Portal from Bedrock/End_Portal_Frame should not trigger BlockMultiPlaceEvent
+        // Canceling this event for these blocks causes an upstream item duplication bug.
         // https://github.com/PaperMC/Paper/issues/13586
         return switch (material) {
             case BEDROCK, END_PORTAL_FRAME -> true;
@@ -221,8 +221,6 @@ public class EventAbstractionListener extends AbstractListener {
 
     @EventHandler(ignoreCancelled = true)
     public void onBlockMultiPlace(BlockMultiPlaceEvent event) {
-        // Allow end_portal generation if player can interact with block
-        // avoiding upstream issues
         if (isExemptBlock(event.getBlockPlaced().getType())) {
             return;
         }


### PR DESCRIPTION
if the player has permission to place end_crystal on Bedrock or fill End_Portal_Frame with ender_eye, allow end_portal generation.

can circumvent recently discovered upstream issues.
Members of the Paper team also mentioned that BlockMultiPlaceEvent should only be triggered when a player places blocks like doors or beds, so it is safe to exempt it here.