### PR TITLE
Fix Gradle 8.12 Deprecation Warnings and Checkstyle Violations

### DIFF
--- a/build-logic/src/main/kotlin/buildlogic.artifactory-root.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.artifactory-root.gradle.kts
@@ -1,4 +1,3 @@
-import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 
 plugins {
@@ -13,7 +12,7 @@ if (!project.hasProperty(ARTIFACTORY_CONTEXT_URL)) ext[ARTIFACTORY_CONTEXT_URL] 
 if (!project.hasProperty(ARTIFACTORY_USER)) ext[ARTIFACTORY_USER] = "guest"
 if (!project.hasProperty(ARTIFACTORY_PASSWORD)) ext[ARTIFACTORY_PASSWORD] = ""
 
-configure<ArtifactoryPluginConvention> {
+artifactory {
     setContextUrl("${project.property(ARTIFACTORY_CONTEXT_URL)}")
     clientConfig.publisher.run {
         repoKey = when {

--- a/build-logic/src/main/kotlin/buildlogic.libs.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.libs.gradle.kts
@@ -96,6 +96,9 @@ tasks.register<Jar>("sourcesJar") {
                 it.replaceFirst(textPattern, to)
             }
             path = path.replaceFirst(filePattern, "$1${to.replace('.', '/')}$2")
+            permissions {
+                unix("rw-r--r--")
+            }
         }
     }
     archiveClassifier.set("sources")

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/PaperInterop.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/PaperInterop.java
@@ -26,16 +26,18 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * This class is mainly here to replace PaperLib, as it no longer fully functions on MC 26.1+.
  */
 public class PaperInterop {
+
+    private PaperInterop() {
+    }
 
     public static @Nullable InventoryHolder getHolder(@Nonnull Inventory inventory, boolean useSnapshot) {
         if (PaperLib.isPaper()) {
@@ -45,7 +47,7 @@ public class PaperInterop {
         return inventory.getHolder();
     }
 
-    public static @NotNull BlockState getBlockState(@Nonnull Block block, boolean useSnapshot) {
+    public static @Nonnull BlockState getBlockState(@Nonnull Block block, boolean useSnapshot) {
         if (PaperLib.isPaper()) {
             return block.getState(useSnapshot);
         }
@@ -53,7 +55,7 @@ public class PaperInterop {
         return block.getState();
     }
 
-    public static @NotNull CompletableFuture<Boolean> teleportAsync(@Nonnull Entity entity, @Nonnull Location location) {
+    public static @Nonnull CompletableFuture<Boolean> teleportAsync(@Nonnull Entity entity, @Nonnull Location location) {
         if (PaperLib.isPaper()) {
             return entity.teleportAsync(location);
         }


### PR DESCRIPTION
Summary
This PR resolves build errors and deprecation warnings that occur when building with Gradle 8.12, ensuring compatibility with future Gradle 9.0 release.

Changes Made
1. Fixed Checkstyle Violations in PaperInterop.java
Replaced JetBrains annotations with javax annotations: Changed @NotNull and @Nullable from org.jetbrains.annotations to @Nonnull and @Nullable from javax.annotation to comply with import control rules

Added private constructor: Added a private constructor to the PaperInterop utility class to satisfy the HideUtilityClassConstructor checkstyle rule

2. Fixed Gradle Deprecation: FileTreeElement.getMode()
Updated file permissions handling: Modified buildlogic.libs.gradle.kts to use the new permissions() API instead of the deprecated getMode() method when processing source files during relocation

Sets explicit Unix permissions (rw-r--r--) for relocated source files

3. Fixed Gradle Deprecation: ConfigureUtil
Modernized Artifactory configuration: Replaced deprecated configure<ArtifactoryPluginConvention> with the artifactory extension block in buildlogic.artifactory-root.gradle.kts

Removed unused ArtifactoryPluginConvention import