### PR TITLE
fix: detect cocoa as a crop

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -1362,7 +1362,7 @@ public final class Materials {
         // yea, that's not all, there are some more
         return switch (type) {
             case PUMPKIN, MELON, CACTUS, SUGAR_CANE, BAMBOO, BAMBOO_SAPLING,
-                    SWEET_BERRY_BUSH, NETHER_WART, CAVE_VINES, CAVE_VINES_PLANT ->
+                 SWEET_BERRY_BUSH, NETHER_WART, CAVE_VINES, CAVE_VINES_PLANT, COCOA ->
                     true;
             default -> false;
         };


### PR DESCRIPTION
Adds the COCOA material to the material crop check. Fixes https://github.com/EngineHub/WorldGuard/issues/2254