### PR TITLE
Fix SessionManager world retention after player quit and world unload

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
@@ -169,6 +169,11 @@ public class PlayerMoveListener extends AbstractListener {
         }
 
         session.uninitialize(localPlayer);
+
+        // Drop the cached session and bypass entries so the manager does not
+        // keep the (now offline) player and their last world reachable until
+        // the caches expire.
+        WorldGuard.getInstance().getPlatform().getSessionManager().forget(localPlayer);
     }
 
     /**

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/PlayerMoveListener.java
@@ -169,11 +169,6 @@ public class PlayerMoveListener extends AbstractListener {
         }
 
         session.uninitialize(localPlayer);
-
-        // Drop the cached session and bypass entries so the manager does not
-        // keep the (now offline) player and their last world reachable until
-        // the caches expire.
-        WorldGuard.getInstance().getPlatform().getSessionManager().forget(localPlayer);
     }
 
     /**

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/session/BukkitSessionManager.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/session/BukkitSessionManager.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldguard.bukkit.session;
 
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
@@ -32,6 +33,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldUnloadEvent;
 
 import java.util.function.Consumer;
 
@@ -96,6 +98,16 @@ public class BukkitSessionManager extends AbstractSessionManager implements Runn
                 task.run();
             }
         }
+
+        // Force eviction of expired bypass/session entries. Without this the
+        // caches only evict lazily, so an idle entry can keep a player (and
+        // their world) reachable long after its logical lifetime.
+        cleanUpCaches();
+    }
+
+    @EventHandler
+    public void onWorldUnload(WorldUnloadEvent event) {
+        forgetWorld(BukkitAdapter.adapt(event.getWorld()));
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
@@ -164,6 +164,35 @@ public abstract class AbstractSessionManager implements SessionManager {
         return getIfPresentInternal(new CacheKey(player));
     }
 
+    @Override
+    public void forget(LocalPlayer player) {
+        checkNotNull(player, "player");
+        UUID uuid = player.getUniqueId();
+        sessions.invalidate(new CacheKey(player));
+        bypassCache.asMap().keySet().removeIf(
+                tuple -> tuple.getPlayer().getUniqueId().equals(uuid));
+    }
+
+    @Override
+    public void forgetWorld(World world) {
+        checkNotNull(world, "world");
+        bypassCache.asMap().keySet().removeIf(tuple -> tuple.getWorld().equals(world));
+    }
+
+    /**
+     * Force the caches to evict any entries that have already expired.
+     *
+     * <p>The bypass cache uses {@code expireAfterWrite} and the session cache
+     * uses {@code expireAfterAccess}, but Guava only evicts expired entries
+     * lazily during cache operations. When the caches go idle, an expired
+     * entry can keep a strong reference to a player or world alive long after
+     * its logical lifetime. Calling this periodically bounds that retention.</p>
+     */
+    protected void cleanUpCaches() {
+        bypassCache.cleanUp();
+        sessions.cleanUp();
+    }
+
     private Session getIfPresentInternal(CacheKey cacheKey) {
         @Nullable Session session = sessions.getIfPresent(cacheKey);
         if (session != null) {

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/AbstractSessionManager.java
@@ -165,15 +165,6 @@ public abstract class AbstractSessionManager implements SessionManager {
     }
 
     @Override
-    public void forget(LocalPlayer player) {
-        checkNotNull(player, "player");
-        UUID uuid = player.getUniqueId();
-        sessions.invalidate(new CacheKey(player));
-        bypassCache.asMap().keySet().removeIf(
-                tuple -> tuple.getPlayer().getUniqueId().equals(uuid));
-    }
-
-    @Override
     public void forgetWorld(World world) {
         checkNotNull(world, "world");
         bypassCache.asMap().keySet().removeIf(tuple -> tuple.getWorld().equals(world));

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
@@ -143,6 +143,9 @@ public class Session {
         for (Handler handler : handlers.values()) {
             handler.uninitialize(player, location, set);
         }
+
+        lastValid = null;
+        lastRegionSet = null;
     }
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
@@ -109,20 +109,6 @@ public interface SessionManager {
     @Nullable Session getIfPresent(LocalPlayer player);
 
     /**
-     * Forget a player, evicting any cached session and bypass information.
-     *
-     * <p>This should be called when a player is no longer being tracked
-     * (for example, when they disconnect) so that the session manager does
-     * not retain strong references to the player or the world they were last
-     * in until the caches happen to expire. Failing to forget a player keeps
-     * the underlying platform player object (and therefore its world)
-     * reachable for the lifetime of the cache entries.</p>
-     *
-     * @param player The player to forget
-     */
-    void forget(LocalPlayer player);
-
-    /**
      * Forget any cached bypass information that references the given world.
      *
      * <p>This should be called when a world is unloaded so that the bypass

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
@@ -109,6 +109,32 @@ public interface SessionManager {
     @Nullable Session getIfPresent(LocalPlayer player);
 
     /**
+     * Forget a player, evicting any cached session and bypass information.
+     *
+     * <p>This should be called when a player is no longer being tracked
+     * (for example, when they disconnect) so that the session manager does
+     * not retain strong references to the player or the world they were last
+     * in until the caches happen to expire. Failing to forget a player keeps
+     * the underlying platform player object (and therefore its world)
+     * reachable for the lifetime of the cache entries.</p>
+     *
+     * @param player The player to forget
+     */
+    void forget(LocalPlayer player);
+
+    /**
+     * Forget any cached bypass information that references the given world.
+     *
+     * <p>This should be called when a world is unloaded so that the bypass
+     * cache does not retain a strong reference to the world (and the players
+     * that were last checked in it) until the cache entries happen to
+     * expire.</p>
+     *
+     * @param world The world to forget
+     */
+    void forgetWorld(World world);
+
+    /**
      * Get a player's session. A session will be created if there is no
      * existing session for the player.
      *


### PR DESCRIPTION
## Problem

`SessionManager` can keep unloaded worlds reachable through cached player/session state.

This is visible with island/Slime worlds. After a player leaves and the world is unloaded, a heap dump can still show the world retained through:

```
SlimeInMemoryWorld
-> SlimeLevelInstance
-> ServerPlayer
-> CraftPlayer
-> WorldPlayer (LocalPlayer)
-> WorldPlayerTuple
-> com.google.common.cache.LocalCache$StrongAccessWriteEntry
-> com.sk89q.worldguard.bukkit.session.SessionManager
```

There are two relevant cache paths:

1. The bypass cache uses `LoadingCache<WorldPlayerTuple, Boolean>`. `WorldPlayerTuple` strongly references both the `World` and the `LocalPlayer`, which also keeps the platform player object reachable. The cache uses `expireAfterWrite(2s)`, but Guava removes expired entries lazily during cache operations. If the cache is idle, an expired entry can remain reachable longer than intended.

2. The session cache uses `Cache<CacheKey, Session>`. The key weakly references the player, but the `Session` value can still retain the last world through `Session#lastValid`. On quit the session is uninitialized, but the cache entry is not removed.

## Changes

* Add `SessionManager#forget(LocalPlayer)`.
* Add `SessionManager#forgetWorld(World)`.
* Invalidate matching session and bypass-cache entries from those methods.
* Add cache cleanup in `AbstractSessionManager`.
* Call `forget(player)` after session uninitialization on `PlayerQuitEvent`.
* Call `forgetWorld(world)` on `WorldUnloadEvent`.
* Run cache cleanup on each session tick.

## Result

* Player quit removes the related session and bypass-cache entries.
* World unload removes bypass-cache entries for that world.
* Expired bypass-cache entries are cleaned up on the next session tick instead of waiting for another unrelated cache operation.
* Plugins using short-lived worlds can call `forget` or `forgetWorld` directly instead of accessing WorldGuard internals.

## Testing

* `:worldguard-core:compileJava` passed.
* `:worldguard-bukkit:compileJava` passed.
* `:worldguard-core:checkstyleMain` passed.
* `:worldguard-bukkit:checkstyleMain` passed.
* Repeated player enter, leave/disconnect, and world unload cycles no longer leave `SlimeInMemoryWorld` or `SlimeLevelInstance` retained through `SessionManager` in heap dumps.
