### PR TITLE
perf: avoid unnecessary isNPC checks

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/InvincibilityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/InvincibilityListener.java
@@ -58,28 +58,27 @@ public class InvincibilityListener extends AbstractListener {
     @EventHandler(ignoreCancelled = true)
     public void onEntityDamage(EntityDamageEvent event) {
         Entity victim = event.getEntity();
-        if (Entities.isNPC(victim)) return;
+        if (!(victim instanceof Player player)) return;
+        if (Entities.isNPC(player)) return;
 
-        if (victim instanceof Player player) {
-            LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
 
-            if (isInvincible(localPlayer)) {
-                player.setFireTicks(0);
-                event.setCancelled(true);
+        if (isInvincible(localPlayer)) {
+            player.setFireTicks(0);
+            event.setCancelled(true);
 
-                if (event instanceof EntityDamageByEntityEvent) {
-                    EntityDamageByEntityEvent byEntityEvent = (EntityDamageByEntityEvent) event;
-                    Entity attacker = byEntityEvent.getDamager();
+            if (event instanceof EntityDamageByEntityEvent) {
+                EntityDamageByEntityEvent byEntityEvent = (EntityDamageByEntityEvent) event;
+                Entity attacker = byEntityEvent.getDamager();
 
-                    if (attacker instanceof Projectile && ((Projectile) attacker).getShooter() instanceof Entity) {
-                        attacker = (Entity) ((Projectile) attacker).getShooter();
-                    }
+                if (attacker instanceof Projectile && ((Projectile) attacker).getShooter() instanceof Entity) {
+                    attacker = (Entity) ((Projectile) attacker).getShooter();
+                }
 
-                    if (getWorldConfig(player.getWorld()).regionInvinciblityRemovesMobs
-                            && attacker instanceof LivingEntity && !(attacker instanceof Player)
-                            && !(attacker instanceof Tameable && ((Tameable) attacker).isTamed())) {
-                        attacker.remove();
-                    }
+                if (getWorldConfig(player.getWorld()).regionInvinciblityRemovesMobs
+                        && attacker instanceof LivingEntity && !(attacker instanceof Player)
+                        && !(attacker instanceof Tameable && ((Tameable) attacker).isTamed())) {
+                    attacker.remove();
                 }
             }
         }
@@ -88,27 +87,25 @@ public class InvincibilityListener extends AbstractListener {
     @EventHandler(ignoreCancelled = true)
     public void onEntityCombust(EntityCombustEvent event) {
         Entity entity = event.getEntity();
-        if (Entities.isNPC(entity)) return;
+        if (!(entity instanceof Player player)) return;
+        if (Entities.isNPC(player)) return;
 
-        if (entity instanceof Player player) {
-            LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
 
-            if (isInvincible(localPlayer)) {
-                event.setCancelled(true);
-            }
+        if (isInvincible(localPlayer)) {
+            event.setCancelled(true);
         }
     }
 
     @EventHandler(ignoreCancelled = true)
     public void onFoodLevelChange(FoodLevelChangeEvent event) {
-        if (Entities.isNPC(event.getEntity())) return;
+        if (!(event.getEntity() instanceof Player player)) return;
+        if (Entities.isNPC(player)) return;
 
-        if (event.getEntity() instanceof Player player) {
-            LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
 
-            if (event.getFoodLevel() < player.getFoodLevel() && isInvincible(localPlayer)) {
-                event.setCancelled(true);
-            }
+        if (event.getFoodLevel() < player.getFoodLevel() && isInvincible(localPlayer)) {
+            event.setCancelled(true);
         }
     }
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionFlagsListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionFlagsListener.java
@@ -119,8 +119,8 @@ public class RegionFlagsListener extends AbstractListener {
         World world = entity.getWorld();
         if (!isRegionSupportEnabled(world)) return; // Region support disabled
 
-        if (Entities.isNPC(entity)) return;
         if (!(entity instanceof Player player)) return;
+        if (Entities.isNPC(player)) return;
 
         RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -410,7 +410,7 @@ public class RegionProtectionListener extends AbstractListener {
         final Entity entity = event.getEntity();
         final EntityType type = entity.getType();
         if (Entities.isHostile(entity) || Entities.isAmbient(entity)
-                || Entities.isNPC(entity) || entity instanceof Player) {
+                || entity instanceof Player || Entities.isNPC(entity)) {
             canUse = event.getRelevantFlags().isEmpty() || query.queryState(BukkitAdapter.adapt(target), associable, combine(event)) != State.DENY;
             what = "use that";
         /* Paintings, item frames, etc. */

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -789,8 +789,8 @@ public class WorldGuardEntityListener extends AbstractListener {
     public void onFoodChange(FoodLevelChangeEvent event) {
         if (event.getItem() != null) return;
         HumanEntity ent = event.getEntity();
-        if (Entities.isNPC(ent)) return;
         if (!(ent instanceof Player bukkitPlayer)) return;
+        if (Entities.isNPC(bukkitPlayer)) return;
         if (event.getFoodLevel() > ent.getFoodLevel()) return;
 
         LocalPlayer player = WorldGuardPlugin.inst().wrapPlayer(bukkitPlayer);


### PR DESCRIPTION
Check whether an entity is a Player before calling `isNPC()` in player-only listeners, avoiding unnecessary NPC checks.

No behavioral changes intended.