### PR TITLE
Filter "standing in" regions list by permission access. Fixes #2262

### DIFF
--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommands.java
@@ -76,7 +76,6 @@ import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion.CircularInheritanceException;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
-import com.sk89q.worldguard.protection.util.DomainInputResolver.UserLocatorPolicy;
 import com.sk89q.worldguard.protection.util.WorldEditRegionConverter;
 import com.sk89q.worldguard.session.Session;
 import com.sk89q.worldguard.util.Enums;
@@ -351,6 +350,7 @@ public final class RegionCommands extends RegionCommandsBase {
         World world = checkWorld(args, sender, 'w');
         RegionManager manager = checkRegionManager(world);
         ProtectedRegion existing;
+        RegionPermissionModel permissionModel = getPermissionModel(sender);
 
         // If no arguments were given, get the region that the player is inside
         if (args.argsLength() == 0) {
@@ -359,13 +359,13 @@ public final class RegionCommands extends RegionCommandsBase {
                 throw new CommandException("Please specify a region name."); // just don't allow that
             }
             world = player.getWorld();
-            existing = checkRegionStandingIn(manager, player, "/rg select -w \"" + world.getName() + "\" %id%");
+            existing = checkRegionStandingIn(manager, player, "/rg select -w \"" + world.getName() + "\" %id%", permissionModel::maySelect);
         } else {
             existing = checkExistingRegion(manager, args.getString(0), false);
         }
 
         // Check permissions
-        if (!getPermissionModel(sender).maySelect(existing)) {
+        if (!permissionModel.maySelect(existing)) {
             throw new CommandPermissionsException();
         }
 
@@ -401,7 +401,7 @@ public final class RegionCommands extends RegionCommandsBase {
             }
 
             existing = checkRegionStandingIn(manager, (LocalPlayer) sender, true,
-                    "/rg info -w \"" + world.getName() + "\" %id%" + (args.hasFlag('u') ? " -u" : "") + (args.hasFlag('s') ? " -s" : ""));
+                    "/rg info -w \"" + world.getName() + "\" %id%" + (args.hasFlag('u') ? " -u" : "") + (args.hasFlag('s') ? " -s" : ""), permModel::mayLookup);
         } else { // Get region from the ID
             existing = checkExistingRegion(manager, args.getString(0), true);
         }
@@ -661,18 +661,19 @@ public final class RegionCommands extends RegionCommandsBase {
         // Lookup the existing region
         RegionManager manager = checkRegionManager(world);
         ProtectedRegion region;
+        final RegionPermissionModel perms = getPermissionModel(sender);
+
         if (args.argsLength() == 0) { // Get region from where the player is
             if (!(sender instanceof LocalPlayer)) {
                 throw new CommandException("Please specify the region with /region flags -w world_name region_name.");
             }
 
             region = checkRegionStandingIn(manager, (LocalPlayer) sender, true,
-                    "/rg flags -w \"" + world.getName() + "\" %id%");
+                    "/rg flags -w \"" + world.getName() + "\" %id%", perms::mayLookup);
         } else { // Get region from the ID
             region = checkExistingRegion(manager, args.getString(0), true);
         }
 
-        final RegionPermissionModel perms = getPermissionModel(sender);
         if (!perms.mayLookup(region)) {
             throw new CommandPermissionsException();
         }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
@@ -32,15 +32,12 @@ import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Polygonal2DRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
-import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
-import com.sk89q.worldedit.regions.selector.Polygonal2DRegionSelector;
 import com.sk89q.worldedit.util.formatting.component.ErrorFormat;
 import com.sk89q.worldedit.util.formatting.component.SubtleFormat;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.event.ClickEvent;
 import com.sk89q.worldedit.util.formatting.text.event.HoverEvent;
 import com.sk89q.worldedit.util.formatting.text.format.TextColor;
-import com.sk89q.worldedit.util.formatting.text.format.TextDecoration;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
@@ -59,6 +56,7 @@ import com.sk89q.worldguard.protection.regions.RegionQuery.QueryOption;
 import com.sk89q.worldguard.protection.util.WorldEditRegionConverter;
 
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 class RegionCommandsBase {
@@ -178,11 +176,13 @@ class RegionCommandsBase {
      *
      * @param regionManager the region manager
      * @param player the player
+     * @param rgCmd the command to construct when clicking one of multiple items
+     * @param permissionPredicate a predicate to filter regions based on permission access
      * @return a region
      * @throws CommandException thrown if no region was found
      */
-    protected static ProtectedRegion checkRegionStandingIn(RegionManager regionManager, LocalPlayer player, String rgCmd) throws CommandException {
-        return checkRegionStandingIn(regionManager, player, false, rgCmd);
+    protected static ProtectedRegion checkRegionStandingIn(RegionManager regionManager, LocalPlayer player, String rgCmd, Predicate<ProtectedRegion> permissionPredicate) throws CommandException {
+        return checkRegionStandingIn(regionManager, player, false, rgCmd, permissionPredicate);
     }
 
     /**
@@ -197,13 +197,17 @@ class RegionCommandsBase {
      * @param regionManager the region manager
      * @param player the player
      * @param allowGlobal whether to search for a global region if no others are found
+     * @param rgCmd the command to construct when clicking one of multiple items
+     * @param permissionPredicate a predicate to filter regions based on permission access
      * @return a region
      * @throws CommandException thrown if no region was found
      */
-    protected static ProtectedRegion checkRegionStandingIn(RegionManager regionManager, LocalPlayer player, boolean allowGlobal, String rgCmd) throws CommandException {
+    protected static ProtectedRegion checkRegionStandingIn(RegionManager regionManager, LocalPlayer player, boolean allowGlobal, String rgCmd, Predicate<ProtectedRegion> permissionPredicate) throws CommandException {
         ApplicableRegionSet set = regionManager.getApplicableRegions(player.getLocation().toVector().toBlockPoint(), QueryOption.SORT);
 
-        if (set.size() == 0) {
+        Set<ProtectedRegion> filteredRegions = set.getRegions().stream().filter(permissionPredicate).collect(Collectors.toSet());
+
+        if (filteredRegions.isEmpty()) {
             if (allowGlobal) {
                 ProtectedRegion global = checkExistingRegion(regionManager, "__global__", true);
                 player.printDebug("You're not standing in any " +
@@ -213,12 +217,12 @@ class RegionCommandsBase {
             throw new CommandException(
                     "You're not standing in a region. " +
                             "Specify an ID if you want to select a specific region.");
-        } else if (set.size() > 1) {
+        } else if (filteredRegions.size() > 1) {
             boolean first = true;
 
             final TextComponent.Builder builder = TextComponent.builder("");
             builder.append(TextComponent.of("Current regions: ", TextColor.GOLD));
-            for (ProtectedRegion region : set) {
+            for (ProtectedRegion region : filteredRegions) {
                 if (!first) {
                     builder.append(TextComponent.of(", "));
                 }
@@ -234,7 +238,7 @@ class RegionCommandsBase {
             throw new CommandException("You're standing in several regions (please pick one).");
         }
 
-        return set.iterator().next();
+        return filteredRegions.iterator().next();
     }
 
     /**

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/commands/region/RegionCommandsBase.java
@@ -205,9 +205,7 @@ class RegionCommandsBase {
     protected static ProtectedRegion checkRegionStandingIn(RegionManager regionManager, LocalPlayer player, boolean allowGlobal, String rgCmd, Predicate<ProtectedRegion> permissionPredicate) throws CommandException {
         ApplicableRegionSet set = regionManager.getApplicableRegions(player.getLocation().toVector().toBlockPoint(), QueryOption.SORT);
 
-        Set<ProtectedRegion> filteredRegions = set.getRegions().stream().filter(permissionPredicate).collect(Collectors.toSet());
-
-        if (filteredRegions.isEmpty()) {
+        if (set.size() == 0) {
             if (allowGlobal) {
                 ProtectedRegion global = checkExistingRegion(regionManager, "__global__", true);
                 player.printDebug("You're not standing in any " +
@@ -217,28 +215,38 @@ class RegionCommandsBase {
             throw new CommandException(
                     "You're not standing in a region. " +
                             "Specify an ID if you want to select a specific region.");
-        } else if (filteredRegions.size() > 1) {
+        } else if (set.size() > 1) {
             boolean first = true;
+            Set<ProtectedRegion> filteredRegions = set.getRegions().stream().filter(permissionPredicate).collect(Collectors.toSet());
+            int hiddenRegions = set.size() - filteredRegions.size();
 
             final TextComponent.Builder builder = TextComponent.builder("");
-            builder.append(TextComponent.of("Current regions: ", TextColor.GOLD));
-            for (ProtectedRegion region : filteredRegions) {
-                if (!first) {
-                    builder.append(TextComponent.of(", "));
+            if (!filteredRegions.isEmpty()) {
+                builder.append(TextComponent.of("Current regions: ", TextColor.GOLD));
+                for (ProtectedRegion region : filteredRegions) {
+                    if (!first) {
+                        builder.append(TextComponent.of(", "));
+                    }
+                    first = false;
+                    TextComponent regionComp = TextComponent.of(region.getId(), TextColor.AQUA);
+                    if (rgCmd != null && rgCmd.contains("%id%")) {
+                        regionComp = regionComp.hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to pick this region")))
+                                .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND, rgCmd.replace("%id%", region.getId())));
+                    }
+                    builder.append(regionComp);
                 }
-                first = false;
-                TextComponent regionComp = TextComponent.of(region.getId(), TextColor.AQUA);
-                if (rgCmd != null && rgCmd.contains("%id%")) {
-                    regionComp = regionComp.hoverEvent(HoverEvent.of(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Click to pick this region")))
-                            .clickEvent(ClickEvent.of(ClickEvent.Action.RUN_COMMAND, rgCmd.replace("%id%", region.getId())));
+                if (hiddenRegions > 0) {
+                    builder.append(TextComponent.of(", and " + hiddenRegions + " hidden regions", TextColor.GRAY));
                 }
-                builder.append(regionComp);
+            } else {
+                builder.append(TextComponent.of("Current regions: ", TextColor.GOLD));
+                builder.append(TextComponent.of(hiddenRegions + " hidden regions", TextColor.GRAY));
             }
             player.print(builder.build());
             throw new CommandException("You're standing in several regions (please pick one).");
         }
 
-        return filteredRegions.iterator().next();
+        return set.iterator().next();
     }
 
     /**


### PR DESCRIPTION
This PR fixes #2262 by filtering the list of available regions in "checkRegionStandingIn" by a permission lookup. While leaking the region names isn't much of a big deal, it can be confusing to the user to see a list of regions they do not have access to. This filters the list by what the player can actually use.

Don't need to permission gate global here as it's never displayed to the player, and worst case if returned it'll be hit by the permissions check in the actual command.