### PR TITLE
Add Cause tracking for SulfurCube

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/cause/Cause.java
@@ -40,6 +40,7 @@ import org.bukkit.entity.Firework;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.entity.SulfurCube;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Vehicle;
@@ -117,7 +118,7 @@ public final class Cause {
             return false;
         }
 
-        if (object instanceof TNTPrimed || object instanceof Vehicle) {
+        if (object instanceof TNTPrimed || object instanceof Vehicle || object instanceof SulfurCube) {
             if (!PaperLib.isPaper()) {
                 return false;
             }

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/EventAbstractionListener.java
@@ -83,6 +83,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.SulfurCube;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.entity.WindCharge;
@@ -895,7 +896,18 @@ public class EventAbstractionListener extends AbstractListener {
         if (matchingItem != null && hasInteractBypass(world, matchingItem)) {
             useEntityEvent.setAllowed(true);
         }
-        Events.fireToCancel(event, useEntityEvent);
+        if (!Events.fireToCancel(event, useEntityEvent)) {
+            /* Sulfur cube doesn't have API for interaction/ignition source tracking */
+            if(entity instanceof SulfurCube) {
+                /* Remove player in case of using shears */
+                if(item.getType() == Material.SHEARS) {
+                    Cause.untrackParentCause(entity);
+                /* Save player overwise */
+                } else {
+                    Cause.trackParentCause(entity, player);
+                }
+            }
+        }
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -917,6 +929,8 @@ public class EventAbstractionListener extends AbstractListener {
                 eventToFire.getRelevantFlags().add(Flags.FIREWORK_DAMAGE);
             } else if (damager instanceof Creeper) {
                 eventToFire.getRelevantFlags().add(Flags.CREEPER_EXPLOSION);
+            } else if (damager instanceof SulfurCube) {
+                eventToFire.getRelevantFlags().add(Flags.TNT);
             }
             if (Events.fireToCancel(event, eventToFire)) {
                 if (damager instanceof Tameable && damager instanceof Mob) {

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -57,6 +57,7 @@ import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.SulfurCube;
 import org.bukkit.entity.Tameable;
 import org.bukkit.event.Event;
 import org.bukkit.event.Event.Result;
@@ -222,7 +223,7 @@ public class RegionProtectionListener extends AbstractListener {
                 String what;
 
                 /* TNT */
-                if (event.getCause().find(EntityType.TNT, EntityType.TNT_MINECART) != null) {
+                if (event.getCause().find(EntityType.TNT, EntityType.TNT_MINECART, EntityType.SULFUR_CUBE) != null) {
                     canBreak = query.testBuild(BukkitAdapter.adapt(target), associable, combine(event, Flags.BLOCK_BREAK, Flags.TNT));
                     what = "use dynamite";
 

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -61,6 +61,7 @@ import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.entity.SulfurCube;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.WindCharge;
@@ -487,7 +488,7 @@ public class WorldGuardEntityListener extends AbstractListener {
                 event.blockList().clear();
                 return;
             }
-        } else if (ent instanceof TNTPrimed || ent instanceof ExplosiveMinecart) {
+        } else if (ent instanceof TNTPrimed || ent instanceof ExplosiveMinecart || ent instanceof SulfurCube) {
             if (wcfg.blockTNTExplosions) {
                 event.setCancelled(true);
                 return;
@@ -615,7 +616,8 @@ public class WorldGuardEntityListener extends AbstractListener {
                 return;
             }
         } else if (event.getEntityType() == EntityType.TNT
-                || event.getEntityType() == EntityType.TNT_MINECART) {
+                || event.getEntityType() == EntityType.TNT_MINECART
+                || event.getEntityType() == EntityType.SULFUR_CUBE) {
             if (wcfg.blockTNTExplosions) {
                 event.setCancelled(true);
                 return;

--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/util/Entities.java
@@ -43,6 +43,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.SpectralArrow;
 import org.bukkit.entity.Steerable;
+import org.bukkit.entity.SulfurCube;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Vehicle;
@@ -78,7 +79,9 @@ public final class Entities {
      * @return true if TNT based
      */
     public static boolean isTNTBased(Entity entity) {
-        return entity instanceof TNTPrimed || entity instanceof ExplosiveMinecart;
+        return entity instanceof TNTPrimed
+                || entity instanceof ExplosiveMinecart
+                || entity instanceof SulfurCube sulfurCube && sulfurCube.canExplode();
     }
 
     /**
@@ -265,6 +268,7 @@ public final class Entities {
             case Wither wither -> Flags.WITHER_DAMAGE;
             case Creeper creeper -> Flags.CREEPER_EXPLOSION;
             case TNTPrimed tnt -> Flags.TNT;
+            case SulfurCube sulfurCube -> Flags.TNT;
             case ExplosiveMinecart minecart -> Flags.TNT;
             case EnderDragon dragon -> Flags.ENDERDRAGON_BLOCK_DAMAGE;
             case null, default -> Flags.OTHER_EXPLOSION;


### PR DESCRIPTION
This PR fixes #2294.

Explosive archetype of sulfur cube is dangerous by default and cause damage to blocks. Sulfur cubes can transform to explosive by consuming a TNT block: from player's direct interaction or by grabbing dropped item. Damage from sulfur cube may be disabled with `other-explosion: DENY` flag, but there is no fun to disable it everywhere.

This PR brings more consistent approach: sulfur cube with TNT acts like normal tnt and explosive minecarts at once. I added Cause tracking for every interaction. Insertion block by player will track the root cause of possible destruction. This means that sulfur cube with TNT inserted by non-MEMBER and pushed to protected region would not harm any blocks. Even feeding a cube with TNT-item within protected region and pushing to any redstone block will be safe for region, because cube itself will treated as non-MEMBER. But cube, created by MEMBER or OWNER still can explode blocks if flag `tnt` is not set to DENY.

But there are still more caveates in latest version of Paper:
- WorldGuard prevents stealing cube with bucket, but sulfur cube will disappear. It's only client-side, bug reported: https://github.com/PaperMC/Paper/issues/14113
- Player still can spawn cube within protected region if player aims into another entity and pointing "through" entity on near block. According to logs every interaction event is cancelled, but cube still spawns. Not sure if it a WorldGuard issue.
- Cube's explosion can trigger nearby explosive sulfur cubes. Damage events are cancelled by WorldGuard as well, but cubes somehow don't care. Not sure if it a WorldGuard issue again

Also not sure if this PR meets all requirements/code style, but I tried to do my best.