### PR TITLE
Fix lock flag restoration after session reinitialization

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/session/BukkitSessionManager.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/session/BukkitSessionManager.java
@@ -43,8 +43,8 @@ import java.util.function.Consumer;
 public class BukkitSessionManager extends AbstractSessionManager implements Runnable, Listener {
 
     /**
-     * Re-initialize handlers and clear "last position," "last state," etc.
-     * information for all players.
+     * Restore handler-managed state, re-initialize handlers, and clear
+     * "last position," "last state," etc. information for all players.
      */
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -72,9 +72,14 @@ public class BukkitSessionManager extends AbstractSessionManager implements Runn
 
     @EventHandler
     public void onPlayerProcess(ProcessPlayerEvent event) {
-        // Pre-load a session
+        // Create a new session or re-initialize a cached one.
         LocalPlayer player = WorldGuardPlugin.inst().wrapPlayer(event.getPlayer());
-        get(player).initialize(player);
+        Session session = getIfPresent(player);
+        if (session == null) {
+            get(player); // this also initializes the new session
+        } else {
+            session.resetState(player); // old sessions need explicit re-initialization 
+        }
     }
 
     @Override

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/Session.java
@@ -161,11 +161,12 @@ public class Session {
     }
 
     /**
-     * Re-initialize the session.
+     * Restore handler-managed state and then re-initialize the session.
      *
      * @param player The player
      */
     public void resetState(LocalPlayer player) {
+        uninitialize(player);
         initialize(player);
         needRefresh.set(true);
     }

--- a/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
+++ b/worldguard-core/src/main/java/com/sk89q/worldguard/session/SessionManager.java
@@ -41,14 +41,14 @@ public interface SessionManager {
     boolean hasBypass(LocalPlayer player, World world);
 
     /**
-     * Re-initialize handlers and clear "last position," "last state," etc.
-     * information for all players.
+     * Restore handler-managed state, re-initialize handlers, and clear
+     * "last position," "last state," etc. information for all players.
      */
     void resetAllStates();
 
     /**
-     * Re-initialize handlers and clear "last position," "last state," etc.
-     * information.
+     * Restore handler-managed state, re-initialize handlers, and clear
+     * "last position," "last state," etc. information.
      *
      * @param player The player
      */


### PR DESCRIPTION
## Summary

Fix player-specific weather and time state restoration when sessions are
reinitialized.

Players could remain stuck with the weather configured by a region's
weather-lock flag after leaving the region. This was reproducible when:

- a new session was initialized while the player was inside a weather-locked
  region (for example login after the server was restarted) or
- /wg flushstates was executed while the player was inside such a region.

Moving out of that region would not reset the weather/time to normal afterwards

## Cause

New sessions were already initialized by SessionManager#get, but the
ProcessPlayerEvent handler initialized them a second time. During the second
initialization, the weather applied by WorldGuard was recorded as the player's
original weather.

Additionally, Session#resetState initialized handlers again without first
uninitializing them. Stateful handlers could therefore replace their original
player state with the state previously applied by the region flag.

## Changes

- Initialize newly created sessions only once.
- Reinitialize cached sessions explicitly on player processing.
- Restore handler-managed player state before reinitializing a session.